### PR TITLE
Introduce contour-crds and contour-gateway-provisioner charts

### DIFF
--- a/charts/contour-crds/.helmignore
+++ b/charts/contour-crds/.helmignore
@@ -1,0 +1,1 @@
+update-crds.sh

--- a/charts/contour-crds/Chart.yaml
+++ b/charts/contour-crds/Chart.yaml
@@ -1,0 +1,17 @@
+annotations:
+  category: Infrastructure
+  licenses: Apache-2.0
+apiVersion: v2
+appVersion: 1.32.0
+description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
+home: https://projectcontour.io/
+keywords:
+- ingress
+- envoy
+- contour
+maintainers:
+- name: Contour Team
+name: contour-crds
+sources:
+- https://github.com/projectcontour/helm-charts/tree/main/charts/contour-crds
+version: 0.1.0

--- a/charts/contour-crds/src/raw-gateway-api-crds.yaml
+++ b/charts/contour-crds/src/raw-gateway-api-crds.yaml
@@ -1,0 +1,14974 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Gateway API Experimental channel install
+#
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendlbpolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendLBPolicy
+    listKind: BackendLBPolicyList
+    plural: backendlbpolicies
+    shortNames:
+    - blbpolicy
+    singular: backendlbpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendLBPolicy provides a way to define load balancing rules
+          for a backend.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendLBPolicy.
+            properties:
+              sessionPersistence:
+                description: |-
+                  SessionPersistence defines and configures session persistence
+                  for the backend.
+
+                  Support: Extended
+                properties:
+                  absoluteTimeout:
+                    description: |-
+                      AbsoluteTimeout defines the absolute timeout of the persistent
+                      session. Once the AbsoluteTimeout duration has elapsed, the
+                      session becomes invalid.
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  cookieConfig:
+                    description: |-
+                      CookieConfig provides configuration settings that are specific
+                      to cookie-based session persistence.
+
+                      Support: Core
+                    properties:
+                      lifetimeType:
+                        default: Session
+                        description: |-
+                          LifetimeType specifies whether the cookie has a permanent or
+                          session-based lifetime. A permanent cookie persists until its
+                          specified expiry time, defined by the Expires or Max-Age cookie
+                          attributes, while a session cookie is deleted when the current
+                          session ends.
+
+                          When set to "Permanent", AbsoluteTimeout indicates the
+                          cookie's lifetime via the Expires or Max-Age cookie attributes
+                          and is required.
+
+                          When set to "Session", AbsoluteTimeout indicates the
+                          absolute lifetime of the cookie tracked by the gateway and
+                          is optional.
+
+                          Support: Core for "Session" type
+
+                          Support: Extended for "Permanent" type
+                        enum:
+                        - Permanent
+                        - Session
+                        type: string
+                    type: object
+                  idleTimeout:
+                    description: |-
+                      IdleTimeout defines the idle timeout of the persistent session.
+                      Once the session has been idle for more than the specified
+                      IdleTimeout duration, the session becomes invalid.
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  sessionName:
+                    description: |-
+                      SessionName defines the name of the persistent session token
+                      which may be reflected in the cookie or the header. Users
+                      should avoid reusing session names to prevent unintended
+                      consequences, such as rejection or unpredictable behavior.
+
+                      Support: Implementation-specific
+                    maxLength: 128
+                    type: string
+                  type:
+                    default: Cookie
+                    description: |-
+                      Type defines the type of session persistence such as through
+                      the use a header or cookie. Defaults to cookie based session
+                      persistence.
+
+                      Support: Core for "Cookie" type
+
+                      Support: Extended for "Header" type
+                    enum:
+                    - Cookie
+                    - Header
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                    is Permanent
+                  rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                    || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+              targetRefs:
+                description: |-
+                  TargetRef identifies an API object to apply policy to.
+                  Currently, Backends (i.e. Service, ServiceImport, or any
+                  implementation-specific backendRef) are the only valid API
+                  target references.
+                items:
+                  description: |-
+                    LocalPolicyTargetReference identifies an API object to apply a direct or
+                    inherited policy to. This should be used as part of Policy resources
+                    that can target Gateway API resources. For more information on how this
+                    policy attachment model works, and a sample Policy resource, refer to
+                    the policy attachment documentation for Gateway API.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - kind
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - targetRefs
+            type: object
+          status:
+            description: Status defines the current state of BackendLBPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+                  Support: Extended for Kubernetes Service
+
+                  Support: Implementation-specific for any other resource
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                      References to a resource in a different namespace are invalid for the
+                      moment, although we will revisit this in the future.
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+                      Support: Implementation-specific (More than one reference, or other kinds
+                      of resources).
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. If SubjectAltNames is not specified, Hostname MUST be used for
+                         authentication and MUST match the certificate served by the matching
+                         backend.
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified, the certificate served from the backend MUST have at least one
+                      Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Core
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether system CA certificates may be used in
+                      the TLS handshake between the gateway and backend pod.
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                      implementation does not support the WellKnownCACertificates field or the value
+                      supplied is not supported, the Status Conditions on the Policy MUST be
+                      updated to include an Accepted: False Condition with Reason: Invalid.
+
+                      Support: Implementation-specific
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: gateways.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gtw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway represents an instance of a service-traffic handling infrastructure
+          by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses requested for this Gateway. This is optional and behavior can
+                  depend on the implementation. If a value is set in the spec and the
+                  requested address is invalid or unavailable, the implementation MUST
+                  indicate this in the associated entry in GatewayStatus.Addresses.
+
+                  The Addresses field represents a request for the address(es) on the
+                  "outside of the Gateway", that traffic bound for this Gateway will use.
+                  This could be the IP address or hostname of an external load balancer or
+                  other networking infrastructure, or some other address that traffic will
+                  be sent to.
+
+                  If no Addresses are specified, the implementation MAY schedule the
+                  Gateway in an implementation-specific manner, assigning an appropriate
+                  set of Addresses.
+
+                  The implementation MUST bind all Listeners to every GatewayAddress that
+                  it assigns to the Gateway and add a corresponding entry in
+                  GatewayStatus.Addresses.
+
+                  Support: Extended
+
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+              backendTLS:
+                description: |+
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+
+                properties:
+                  clientCertificateRef:
+                    description: |+
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              gatewayClassName:
+                description: |-
+                  GatewayClassName used for this Gateway. This is the name of a
+                  GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: |-
+                  Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+                  Support: Extended
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: |-
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: |-
+                      Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+                      An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: |-
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+                      An implementation may chose to add additional implementation-specific labels as they see fit.
+
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: |-
+                      ParametersRef is a reference to a resource that contains the configuration
+                      parameters corresponding to the Gateway. This is optional if the
+                      controller does not require any additional configuration.
+
+                      This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+                      The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                      the merging behavior is implementation specific.
+                      It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                      Support: Implementation-specific
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: |-
+                  Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses.
+                  At least one Listener MUST be specified.
+
+                  Each Listener in a set of Listeners (for example, in a single Gateway)
+                  MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                  exactly one listener. (This section uses "set of Listeners" rather than
+                  "Listeners in a single Gateway" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules _also_
+                  apply in that case).
+
+                  Practically, this means that each listener in a set MUST have a unique
+                  combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+                  Some combinations of port, protocol, and TLS settings are considered
+                  Core support and MUST be supported by implementations based on their
+                  targeted conformance profile:
+
+                  HTTP Profile
+
+                  1. HTTPRoute, Port: 80, Protocol: HTTP
+                  2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+                  TLS Profile
+
+                  1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+                  "Distinct" Listeners have the following property:
+
+                  The implementation can match inbound requests to a single distinct
+                  Listener. When multiple Listeners share values for fields (for
+                  example, two Listeners with the same Port value), the implementation
+                  can match requests to only one of the Listeners using other
+                  Listener fields.
+
+                  For example, the following Listener scenarios are distinct:
+
+                  1. Multiple Listeners with the same Port that all use the "HTTP"
+                     Protocol that all have unique Hostname values.
+                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                     "TLS" Protocol that all have unique Hostname values.
+                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                     with the same Protocol has the same Port value.
+
+                  Some fields in the Listener struct have possible values that affect
+                  whether the Listener is distinct. Hostname is particularly relevant
+                  for HTTP or HTTPS protocols.
+
+                  When using the Hostname value to select between same-Port, same-Protocol
+                  Listeners, the Hostname value must be different on each Listener for the
+                  Listener to be distinct.
+
+                  When the Listeners are distinct based on Hostname, inbound request
+                  hostnames MUST match from the most specific to least specific Hostname
+                  values to choose the correct Listener and its associated set of Routes.
+
+                  Exact matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. For example, `"foo.example.com"` takes precedence over
+                  `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+                  Additionally, if there are multiple wildcard entries, more specific
+                  wildcard entries must be processed before less specific wildcard entries.
+                  For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                  The precise definition here is that the higher the number of dots in the
+                  hostname to the right of the wildcard character, the higher the precedence.
+
+                  The wildcard character will match any number of characters _and dots_ to
+                  the left, however, so `"*.example.com"` will match both
+                  `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+                  If a set of Listeners contains Listeners that are not distinct, then those
+                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  condition in the Listener Status to "True".
+
+                  Implementations MAY choose to accept a Gateway with some Conflicted
+                  Listeners only if they only accept the partial Listener set that contains
+                  no Conflicted Listeners. To put this another way, implementations may
+                  accept a partial Listener set only if they throw out *all* the conflicting
+                  Listeners. No picking one of the conflicting listeners as the winner.
+                  This also means that the Gateway must have at least one non-conflicting
+                  Listener in this case, otherwise it violates the requirement that at
+                  least one Listener must be present.
+
+                  The implementation MUST set a "ListenersNotValid" condition on the
+                  Gateway Status when the Gateway contains Conflicted Listeners whether or
+                  not they accept the Gateway. That Condition SHOULD clearly
+                  indicate in the Message which Listeners are conflicted, and which are
+                  Accepted. Additionally, the Listener status for those listeners SHOULD
+                  indicate which Listeners are conflicted and not Accepted.
+
+                  A Gateway's Listeners are considered "compatible" if:
+
+                  1. They are distinct.
+                  2. The implementation can serve them in compliance with the Addresses
+                     requirement that all Listeners are available on all assigned
+                     addresses.
+
+                  Compatible combinations in Extended support are expected to vary across
+                  implementations. A combination that is compatible for one implementation
+                  may not be compatible for another.
+
+                  For example, an implementation that cannot serve both TCP and UDP listeners
+                  on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                  would not consider those cases compatible, even though they are distinct.
+
+                  Note that requests SHOULD match at most one Listener. For example, if
+                  Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                  This concept is known as "Listener Isolation". Implementations that do
+                  not support Listener Isolation MUST clearly document this.
+
+                  Implementations MAY merge separate Gateways onto a single set of
+                  Addresses if all Listeners across all Gateways are compatible.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Listener embodies the concept of a logical endpoint where a Gateway accepts
+                    network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+
+                        Support: Core
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+
+                        Support: Core
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol specifies the network protocol this listener expects to receive.
+
+                        Support: Core
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+
+                        Support: Core
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                            Support: Extended
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses lists the network addresses that have been bound to the
+                  Gateway.
+
+                  This list may differ from the addresses provided in the spec under some
+                  conditions:
+
+                    * no addresses are specified, all addresses are dynamically assigned
+                    * a combination of specified and dynamic addresses are assigned
+                    * a specified address was unusable (e.g. already in use)
+
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the Gateway.
+
+                  Implementations should prefer to express Gateway conditions
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe Gateway state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                  * "Ready"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners with condition Accepted: false and MUST count successfully
+                        attached Routes that may themselves have Accepted: false conditions.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds an implementation supports for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Gateway represents an instance of a service-traffic handling infrastructure
+          by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses requested for this Gateway. This is optional and behavior can
+                  depend on the implementation. If a value is set in the spec and the
+                  requested address is invalid or unavailable, the implementation MUST
+                  indicate this in the associated entry in GatewayStatus.Addresses.
+
+                  The Addresses field represents a request for the address(es) on the
+                  "outside of the Gateway", that traffic bound for this Gateway will use.
+                  This could be the IP address or hostname of an external load balancer or
+                  other networking infrastructure, or some other address that traffic will
+                  be sent to.
+
+                  If no Addresses are specified, the implementation MAY schedule the
+                  Gateway in an implementation-specific manner, assigning an appropriate
+                  set of Addresses.
+
+                  The implementation MUST bind all Listeners to every GatewayAddress that
+                  it assigns to the Gateway and add a corresponding entry in
+                  GatewayStatus.Addresses.
+
+                  Support: Extended
+
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+              backendTLS:
+                description: |+
+                  BackendTLS configures TLS settings for when this Gateway is connecting to
+                  backends with TLS.
+
+                  Support: Core
+
+                properties:
+                  clientCertificateRef:
+                    description: |+
+                      ClientCertificateRef is a reference to an object that contains a Client
+                      Certificate and the associated private key.
+
+                      References to a resource in different namespace are invalid UNLESS there
+                      is a ReferenceGrant in the target namespace that allows the certificate
+                      to be attached. If a ReferenceGrant does not allow this reference, the
+                      "ResolvedRefs" condition MUST be set to False for this listener with the
+                      "RefNotPermitted" reason.
+
+                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                      Secret, or implementation-specific custom resources.
+
+                      This setting can be overridden on the service level by use of BackendTLSPolicy.
+
+                      Support: Core
+
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              gatewayClassName:
+                description: |-
+                  GatewayClassName used for this Gateway. This is the name of a
+                  GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: |-
+                  Infrastructure defines infrastructure level attributes about this Gateway instance.
+
+                  Support: Extended
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: |-
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: |-
+                      Annotations that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
+
+                      An implementation may chose to add additional implementation-specific annotations as they see fit.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: |-
+                        LabelValue is the value of a label in the Gateway API. This is used for validation
+                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
+                        label validation rules:
+                        * must be 63 characters or less (can be empty),
+                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+
+                        Valid values include:
+
+                        * MyValue
+                        * my.name
+                        * 123-my-value
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: |-
+                      Labels that SHOULD be applied to any resources created in response to this Gateway.
+
+                      For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
+                      For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
+
+                      An implementation may chose to add additional implementation-specific labels as they see fit.
+
+                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+                      Support: Extended
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: |-
+                      ParametersRef is a reference to a resource that contains the configuration
+                      parameters corresponding to the Gateway. This is optional if the
+                      controller does not require any additional configuration.
+
+                      This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
+                      The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
+                      the merging behavior is implementation specific.
+                      It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                      Support: Implementation-specific
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: |-
+                  Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses.
+                  At least one Listener MUST be specified.
+
+                  Each Listener in a set of Listeners (for example, in a single Gateway)
+                  MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
+                  exactly one listener. (This section uses "set of Listeners" rather than
+                  "Listeners in a single Gateway" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules _also_
+                  apply in that case).
+
+                  Practically, this means that each listener in a set MUST have a unique
+                  combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
+                  Some combinations of port, protocol, and TLS settings are considered
+                  Core support and MUST be supported by implementations based on their
+                  targeted conformance profile:
+
+                  HTTP Profile
+
+                  1. HTTPRoute, Port: 80, Protocol: HTTP
+                  2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+
+                  TLS Profile
+
+                  1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+
+                  "Distinct" Listeners have the following property:
+
+                  The implementation can match inbound requests to a single distinct
+                  Listener. When multiple Listeners share values for fields (for
+                  example, two Listeners with the same Port value), the implementation
+                  can match requests to only one of the Listeners using other
+                  Listener fields.
+
+                  For example, the following Listener scenarios are distinct:
+
+                  1. Multiple Listeners with the same Port that all use the "HTTP"
+                     Protocol that all have unique Hostname values.
+                  2. Multiple Listeners with the same Port that use either the "HTTPS" or
+                     "TLS" Protocol that all have unique Hostname values.
+                  3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+                     with the same Protocol has the same Port value.
+
+                  Some fields in the Listener struct have possible values that affect
+                  whether the Listener is distinct. Hostname is particularly relevant
+                  for HTTP or HTTPS protocols.
+
+                  When using the Hostname value to select between same-Port, same-Protocol
+                  Listeners, the Hostname value must be different on each Listener for the
+                  Listener to be distinct.
+
+                  When the Listeners are distinct based on Hostname, inbound request
+                  hostnames MUST match from the most specific to least specific Hostname
+                  values to choose the correct Listener and its associated set of Routes.
+
+                  Exact matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. For example, `"foo.example.com"` takes precedence over
+                  `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
+                  Additionally, if there are multiple wildcard entries, more specific
+                  wildcard entries must be processed before less specific wildcard entries.
+                  For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+                  The precise definition here is that the higher the number of dots in the
+                  hostname to the right of the wildcard character, the higher the precedence.
+
+                  The wildcard character will match any number of characters _and dots_ to
+                  the left, however, so `"*.example.com"` will match both
+                  `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+
+                  If a set of Listeners contains Listeners that are not distinct, then those
+                  Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+                  condition in the Listener Status to "True".
+
+                  Implementations MAY choose to accept a Gateway with some Conflicted
+                  Listeners only if they only accept the partial Listener set that contains
+                  no Conflicted Listeners. To put this another way, implementations may
+                  accept a partial Listener set only if they throw out *all* the conflicting
+                  Listeners. No picking one of the conflicting listeners as the winner.
+                  This also means that the Gateway must have at least one non-conflicting
+                  Listener in this case, otherwise it violates the requirement that at
+                  least one Listener must be present.
+
+                  The implementation MUST set a "ListenersNotValid" condition on the
+                  Gateway Status when the Gateway contains Conflicted Listeners whether or
+                  not they accept the Gateway. That Condition SHOULD clearly
+                  indicate in the Message which Listeners are conflicted, and which are
+                  Accepted. Additionally, the Listener status for those listeners SHOULD
+                  indicate which Listeners are conflicted and not Accepted.
+
+                  A Gateway's Listeners are considered "compatible" if:
+
+                  1. They are distinct.
+                  2. The implementation can serve them in compliance with the Addresses
+                     requirement that all Listeners are available on all assigned
+                     addresses.
+
+                  Compatible combinations in Extended support are expected to vary across
+                  implementations. A combination that is compatible for one implementation
+                  may not be compatible for another.
+
+                  For example, an implementation that cannot serve both TCP and UDP listeners
+                  on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+                  would not consider those cases compatible, even though they are distinct.
+
+                  Note that requests SHOULD match at most one Listener. For example, if
+                  Listeners are defined for "foo.example.com" and "*.example.com", a
+                  request to "foo.example.com" SHOULD only be routed using routes attached
+                  to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+                  This concept is known as "Listener Isolation". Implementations that do
+                  not support Listener Isolation MUST clearly document this.
+
+                  Implementations MAY merge separate Gateways onto a single set of
+                  Addresses if all Listeners across all Gateways are compatible.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Listener embodies the concept of a logical endpoint where a Gateway accepts
+                    network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: |-
+                        AllowedRoutes defines the types of routes that MAY be attached to a
+                        Listener and the trusted namespaces where those Route resources MAY be
+                        present.
+
+                        Although a client request may match multiple route rules, only one rule
+                        may ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria:
+
+                        * The most specific match as defined by the Route type.
+                        * The oldest Route based on creation timestamp. For example, a Route with
+                          a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                          a Route with a creation timestamp of "2020-09-08 01:02:04".
+                        * If everything else is equivalent, the Route appearing first in
+                          alphabetical order (namespace/name) should be given precedence. For
+                          example, foo/bar is given precedence over foo/baz.
+
+                        All valid rules within a Route attached to this Listener should be
+                        implemented. Invalid Route rules can be ignored (sometimes that will mean
+                        the full Route). If a Route rule transitions from valid to invalid,
+                        support for that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid, the rest
+                        of the rules within that Route should still be supported.
+
+                        Support: Core
+                      properties:
+                        kinds:
+                          description: |-
+                            Kinds specifies the groups and kinds of Routes that are allowed to bind
+                            to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                            selected are determined using the Listener protocol.
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's Protocol field.
+                            If an implementation does not support or recognize this resource type, it
+                            MUST set the "ResolvedRefs" condition to False for this Listener with the
+                            "InvalidRouteKinds" reason.
+
+                            Support: Core
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: |-
+                            Namespaces indicates namespaces from which Routes may be attached to this
+                            Listener. This is restricted to the namespace of this Gateway by default.
+
+                            Support: Core
+                          properties:
+                            from:
+                              default: Same
+                              description: |-
+                                From indicates where Routes will be selected for this Gateway. Possible
+                                values are:
+
+                                * All: Routes in all namespaces may be used by this Gateway.
+                                * Selector: Routes in namespaces selected by the selector may be used by
+                                  this Gateway.
+                                * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                Support: Core
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: |-
+                                Selector must be specified when From is set to "Selector". In that case,
+                                only Routes in Namespaces matching this Selector will be selected by this
+                                Gateway. This field is ignored for other values of "From".
+
+                                Support: Core
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: |-
+                        Hostname specifies the virtual hostname to match for protocol types that
+                        define this concept. When unspecified, all hostnames are matched. This
+                        field is ignored for protocols that don't require hostname based
+                        matching.
+
+                        Implementations MUST apply Hostname matching appropriately for each of
+                        the following protocols:
+
+                        * TLS: The Listener Hostname MUST match the SNI.
+                        * HTTP: The Listener Hostname MUST match the Host header of the request.
+                        * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                          protocol layers as described above. If an implementation does not
+                          ensure that both the SNI and Host header match the Listener hostname,
+                          it MUST clearly document that.
+
+                        For HTTPRoute and TLSRoute resources, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify hostnames,
+                        there MUST be an intersection between the values for a Route to be
+                        accepted. For more information, refer to the Route specific Hostnames
+                        documentation.
+
+                        Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                        as a suffix match. That means that a match for `*.example.com` would match
+                        both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the Listener. This name MUST be unique within a
+                        Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port. Multiple listeners may use the
+                        same port, subject to the Listener compatibility rules.
+
+                        Support: Core
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: |-
+                        Protocol specifies the network protocol this listener expects to receive.
+
+                        Support: Core
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: |-
+                        TLS is the TLS configuration for the Listener. This field is required if
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        defined based on the Hostname field for this listener.
+
+                        The GatewayClass MUST use the longest matching SNI out of all
+                        available certificates for any TLS handshake.
+
+                        Support: Core
+                      properties:
+                        certificateRefs:
+                          description: |-
+                            CertificateRefs contains a series of references to Kubernetes objects that
+                            contains TLS certificates and private keys. These certificates are used to
+                            establish a TLS handshake for requests that match the hostname of the
+                            associated listener.
+
+                            A single CertificateRef to a Kubernetes Secret has "Core" support.
+                            Implementations MAY choose to support attaching multiple certificates to
+                            a Listener, but this behavior is implementation-specific.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            This field is required to have at least one element when the mode is set
+                            to "Terminate" (default) and is optional otherwise.
+
+                            CertificateRefs can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                            Support: Implementation-specific (More than one reference or other resource types)
+                          items:
+                            description: |-
+                              SecretObjectReference identifies an API object including its namespace,
+                              defaulting to Secret.
+
+                              The API object must be valid in the cluster; the Group and Kind must
+                              be registered in the cluster for this reference to be valid.
+
+                              References to objects with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate Conditions set
+                              on the containing object.
+                            properties:
+                              group:
+                                default: ""
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of the referenced object. When unspecified, the local
+                                  namespace is inferred.
+
+                                  Note that when a namespace different than the local namespace is specified,
+                                  a ReferenceGrant object is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the ReferenceGrant
+                                  documentation for details.
+
+                                  Support: Core
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                            Support: Extended
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
+                        mode:
+                          default: Terminate
+                          description: |-
+                            Mode defines the TLS behavior for the TLS session initiated by the client.
+                            There are two possible modes:
+
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
+                            - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                              implies that the Gateway can't decipher the TLS stream except for
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
+
+                            Support: Core
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: |-
+                              AnnotationValue is the value of an annotation in Gateway API. This is used
+                              for validation of maps such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation in that case is based
+                              on the entire size of the annotations struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: |-
+                            Options are a list of key/value pairs to enable extended TLS
+                            configuration for each implementation. For example, configuring the
+                            minimum TLS version or supported cipher suites.
+
+                            A set of common keys MAY be defined by the API in the future. To avoid
+                            any ambiguity, implementation-specific definitions MUST use
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by Gateway API.
+
+                            Support: Implementation-specific
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: |+
+                  Addresses lists the network addresses that have been bound to the
+                  Gateway.
+
+                  This list may differ from the addresses provided in the spec under some
+                  conditions:
+
+                    * no addresses are specified, all addresses are dynamically assigned
+                    * a combination of specified and dynamic addresses are assigned
+                    * a specified address was unusable (e.g. already in use)
+
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: |-
+                        Value of the address. The validity of the values will depend
+                        on the type and support by the controller.
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the Gateway.
+
+                  Implementations should prefer to express Gateway conditions
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+                  constants so that operators and tools can converge on a common
+                  vocabulary to describe Gateway state.
+
+                  Known condition types are:
+
+                  * "Accepted"
+                  * "Programmed"
+                  * "Ready"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: |-
+                        AttachedRoutes represents the total number of Routes that have been
+                        successfully attached to this Listener.
+
+                        Successful attachment of a Route to a Listener is based solely on the
+                        combination of the AllowedRoutes field on the corresponding Listener
+                        and the Route's ParentRefs field. A Route is successfully attached to
+                        a Listener when it is selected by the Listener's AllowedRoutes field
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+                        resource or a specific Listener as a parent resource (more detail on
+                        attachment semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does not impact
+                        successful attachment, i.e. the AttachedRoutes field count MUST be set
+                        for Listeners with condition Accepted: false and MUST count successfully
+                        attached Routes that may themselves have Accepted: false conditions.
+
+                        Uses for this field include troubleshooting Route attachment and
+                        measuring blast radius/impact of changes to a Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: |-
+                        SupportedKinds is the list indicating the Kinds supported by this
+                        listener. This MUST represent the kinds an implementation supports for
+                        that Listener configuration.
+
+                        If kinds are specified in Spec that are not supported, they MUST NOT
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+                        condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                        and invalid Route kinds are specified, the implementation MUST
+                        reference the valid Route kinds that have been specified.
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: grpcroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GRPCRoute provides a way to route gRPC requests. This includes the capability
+          to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests will be routed.
+
+          GRPCRoute falls under extended support within the Gateway API. Within the
+          following specification, the word "MUST" indicates that an implementation
+          supporting GRPCRoute must conform to the indicated requirement, but an
+          implementation not supporting this route type need not follow the requirement
+          unless explicitly indicated.
+
+          Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+          accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
+          ALPN. If the implementation does not support this, then it MUST set the
+          "Accepted" condition to "False" for the affected listener with a reason of
+          "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+          with an upgrade from HTTP/1.
+
+          Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+          support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+          upgrade from HTTP/1.1, i.e. with prior knowledge
+          (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+          does not support this, then it MUST set the "Accepted" condition to "False"
+          for the affected listener with a reason of "UnsupportedProtocol".
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames to match against the GRPC
+                  Host header to select a GRPCRoute to process the request. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label MUST appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and GRPCRoute, there
+                  MUST be at least one intersecting hostname for the GRPCRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and GRPCRoute have specified hostnames, any
+                  GRPCRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  GRPCRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` MUST NOT be considered for a match.
+
+                  If both the Listener and GRPCRoute have specified hostnames, and none
+                  match with the criteria above, then the GRPCRoute MUST NOT be accepted by
+                  the implementation. The implementation MUST raise an 'Accepted' Condition
+                  with a status of `False` in the corresponding RouteParentStatus.
+
+                  If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
+                  Listener and that listener already has another Route (B) of the other
+                  type attached and the intersection of the hostnames of A and B is
+                  non-empty, then the implementation MUST accept exactly one of these two
+                  routes, determined by the following criteria, in order:
+
+                  * The oldest Route based on creation timestamp.
+                  * The Route appearing first in alphabetical order by
+                    "{namespace}/{name}".
+
+                  The rejected Route MUST raise an 'Accepted' condition with a status of
+                  'False' in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of GRPC matchers, filters and actions.
+
+                items:
+                  description: |-
+                    GRPCRouteRule defines the semantics for matching a gRPC request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive an `UNAVAILABLE` status.
+
+                        See the GRPCBackendRef definition for the rules about what makes a single
+                        GRPCBackendRef invalid.
+
+                        When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive an `UNAVAILABLE` status.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
+                        Implementations may choose how that 50 percent is determined.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level MUST be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in GRPCRouteRule.)
+                            items:
+                              description: |-
+                                GRPCRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. GRPCRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    Support: Implementation-specific
+
+                                    This filter can be used multiple times within the same rule.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |+
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations supporting GRPCRoute MUST support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` MUST be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        The effects of ordering of multiple behaviors are currently unspecified.
+                        This can change in the future based on feedback during the alpha stage.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations that support
+                          GRPCRoute.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        If an implementation can not support a combination of filters, it must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          GRPCRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. GRPCRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              Support: Implementation-specific
+
+                              This filter can be used multiple times within the same rule.
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |+
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations supporting GRPCRoute MUST support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` MUST be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                    matches:
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        gRPC requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - method:
+                            service: foo.bar
+                          headers:
+                            values:
+                              version: 2
+                        - method:
+                            service: foo.bar.v2
+                        ```
+
+                        For a request to match against this rule, it MUST satisfy
+                        EITHER of the two conditions:
+
+                        - service of foo.bar AND contains the header `version: 2`
+                        - service of foo.bar.v2
+
+                        See the documentation for GRPCRouteMatch on how to specify multiple
+                        match conditions to be ANDed together.
+
+                        If no matches are specified, the implementation MUST match every gRPC request.
+
+                        Proxy or Load Balancer routing configuration generated from GRPCRoutes
+                        MUST prioritize rules based on the following criteria, continuing on
+                        ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                        Precedence MUST be given to the rule with the largest number of:
+
+                        * Characters in a matching non-wildcard hostname.
+                        * Characters in a matching hostname.
+                        * Characters in a matching service.
+                        * Characters in a matching method.
+                        * Header matches.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching rule meeting
+                        the above criteria.
+                      items:
+                        description: |-
+                          GRPCRouteMatch defines the predicate used to match requests to a given
+                          action. Multiple match types are ANDed together, i.e. the match will
+                          evaluate to true only if all conditions are satisfied.
+
+                          For example, the match below will match a gRPC request only if its service
+                          is `foo` AND it contains the `version: v1` header:
+
+                          ```
+                          matches:
+                            - method:
+                              type: Exact
+                              service: "foo"
+                              headers:
+                            - name: "version"
+                              value "v1"
+
+                          ```
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies gRPC request header matchers. Multiple match values are
+                              ANDed together, meaning, a request MUST match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the gRPC Header to be matched.
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies a gRPC request service/method matcher. If this field is
+                              not specified, all services and methods will match.
+                            properties:
+                              method:
+                                description: |-
+                                  Value of the method to match against. If left empty or omitted, will
+                                  match all services.
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              service:
+                                description: |-
+                                  Value of the service to match against. If left empty or omitted, will
+                                  match any service.
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              type:
+                                default: Exact
+                                description: |-
+                                  Type specifies how to match against the service and/or method.
+                                  Support: Core (Exact with service and method specified)
+
+                                  Support: Implementation-specific (Exact with method specified but no service specified)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: One or both of 'service' or 'method' must be
+                                specified
+                              rule: 'has(self.type) ? has(self.service) || has(self.method)
+                                : true'
+                            - message: service must only contain valid characters
+                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                                true'
+                            - message: method must only contain valid characters (matching
+                                ^[A-Za-z_][A-Za-z_0-9]*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                                true'
+                        type: object
+                      maxItems: 8
+                      type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size()
+                    : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size()
+                    : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size()
+                    : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size()
+                    : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size()
+                    : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size()
+                    : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size()
+                    : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size()
+                    : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size()
+                    : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size()
+                    : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size()
+                    : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size()
+                    : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size()
+                    : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size()
+                    : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
+                    : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
+                    : 0) : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          HTTPRoute provides a way to route HTTP requests. This includes the capability
+          to match requests by hostname, path, header, or query param. Filters can be
+          used to specify additional processing steps. Backends specify where matching
+          requests should be routed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should match against the HTTP Host
+                  header to select a HTTPRoute used to process the request. Implementations
+                  MUST ignore any port value specified in the HTTP Host header while
+                  performing a match and (absent of any applicable header modification
+                  configuration) MUST forward this header unmodified to the backend.
+
+                  Valid values for Hostnames are determined by RFC 1123 definition of a
+                  hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and HTTPRoute, there
+                  must be at least one intersecting hostname for the HTTPRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+                    all match. On the other hand, `example.com` and `test.example.net` would
+                    not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and HTTPRoute have specified hostnames, any
+                  HTTPRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  HTTPRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and HTTPRoute have specified hostnames, and none
+                  match with the criteria above, then the HTTPRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
+                  overlapping wildcard matching and exact matching hostnames), precedence must
+                  be given to rules from the HTTPRoute with the largest number of:
+
+                  * Characters in a matching non-wildcard hostname.
+                  * Characters in a matching hostname.
+
+                  If ties exist across multiple Routes, the matching precedence rules for
+                  HTTPRouteMatches takes over.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: |+
+                  Rules are a list of HTTP matchers, filters and actions.
+
+                items:
+                  description: |-
+                    HTTPRouteRule defines semantics for matching an HTTP request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive a 500 status code.
+
+                        See the HTTPBackendRef definition for the rules about what makes a single
+                        HTTPBackendRef invalid.
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive a 500 status code.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic must receive a 500. Implementations may
+                        choose how that 50 percent is determined.
+
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level should be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in HTTPRouteRule.)
+                            items:
+                              description: |-
+                                HTTPRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    This filter can be used multiple times within the same rule.
+
+                                    Support: Implementation-specific
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                requestRedirect:
+                                  description: |-
+                                    RequestRedirect defines a schema for a filter that responds to the
+                                    request with an HTTP redirection.
+
+                                    Support: Core
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the hostname to be used in the value of the `Location`
+                                        header in the response.
+                                        When empty, the hostname in the `Host` header of the request is used.
+
+                                        Support: Core
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines parameters used to modify the path of the incoming request.
+                                        The modified path is then used to construct the `Location` header. When
+                                        empty, the request path is used as-is.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: |-
+                                        Port is the port to be used in the value of the `Location`
+                                        header in the response.
+
+                                        If no port is specified, the redirect port MUST be derived using the
+                                        following rules:
+
+                                        * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                          port associated with the redirect scheme. Specifically "http" to port 80
+                                          and "https" to port 443. If the redirect scheme does not have a
+                                          well-known port, the listener port of the Gateway SHOULD be used.
+                                        * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                          Listener port.
+
+                                        Implementations SHOULD NOT add the port number in the 'Location'
+                                        header in the following cases:
+
+                                        * A Location header that will use HTTP (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 80.
+                                        * A Location header that will use HTTPS (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                        Support: Extended
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: |-
+                                        Scheme is the scheme to be used in the value of the `Location` header in
+                                        the response. When empty, the scheme of the request is used.
+
+                                        Scheme redirects can affect the port of the redirect, for more information,
+                                        refer to the documentation for the port field of this filter.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Extended
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: |-
+                                        StatusCode is the HTTP status code to be used in response.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Core
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |-
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations must support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by
+                                      specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` should be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  type: string
+                                urlRewrite:
+                                  description: |-
+                                    URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                                    Support: Extended
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the value to be used to replace the Host header value during
+                                        forwarding.
+
+                                        Support: Extended
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines a path rewrite.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        Wherever possible, implementations SHOULD implement filters in the order
+                        they are specified.
+
+                        Implementations MAY choose to implement this ordering strictly, rejecting
+                        any combination or order of filters that can not be supported. If implementations
+                        choose a strict interpretation of filter ordering, they MUST clearly document
+                        that behavior.
+
+                        To reject an invalid combination or order of filters, implementations SHOULD
+                        consider the Route Rules with this configuration invalid. If all Route Rules
+                        in a Route are invalid, the entire Route would be considered invalid. If only
+                        a portion of Route Rules are invalid, implementations MUST set the
+                        "PartiallyInvalid" condition for the Route.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        All filters are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined. If an
+                        implementation can not support other combinations of filters, they must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          HTTPRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. HTTPRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              This filter can be used multiple times within the same rule.
+
+                              Support: Implementation-specific
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          requestRedirect:
+                            description: |-
+                              RequestRedirect defines a schema for a filter that responds to the
+                              request with an HTTP redirection.
+
+                              Support: Core
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the hostname to be used in the value of the `Location`
+                                  header in the response.
+                                  When empty, the hostname in the `Host` header of the request is used.
+
+                                  Support: Core
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines parameters used to modify the path of the incoming request.
+                                  The modified path is then used to construct the `Location` header. When
+                                  empty, the request path is used as-is.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: |-
+                                  Port is the port to be used in the value of the `Location`
+                                  header in the response.
+
+                                  If no port is specified, the redirect port MUST be derived using the
+                                  following rules:
+
+                                  * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                    port associated with the redirect scheme. Specifically "http" to port 80
+                                    and "https" to port 443. If the redirect scheme does not have a
+                                    well-known port, the listener port of the Gateway SHOULD be used.
+                                  * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                    Listener port.
+
+                                  Implementations SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases:
+
+                                  * A Location header that will use HTTP (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 80.
+                                  * A Location header that will use HTTPS (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                  Support: Extended
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: |-
+                                  Scheme is the scheme to be used in the value of the `Location` header in
+                                  the response. When empty, the scheme of the request is used.
+
+                                  Scheme redirects can affect the port of the redirect, for more information,
+                                  refer to the documentation for the port field of this filter.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Extended
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: |-
+                                  StatusCode is the HTTP status code to be used in response.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Core
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |-
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations must support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by
+                                specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` should be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                              Note that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+
+                              Unknown values here must result in the implementation setting the
+                              Accepted Condition for the Route to `status: False`, with a
+                              Reason of `UnsupportedValue`.
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            type: string
+                          urlRewrite:
+                            description: |-
+                              URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                              Support: Extended
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the value to be used to replace the Host header value during
+                                  forwarding.
+
+                                  Support: Extended
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines a path rewrite.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        HTTP requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - path:
+                            value: "/foo"
+                          headers:
+                          - name: "version"
+                            value: "v2"
+                        - path:
+                            value: "/v2/foo"
+                        ```
+
+                        For a request to match against this rule, a request must satisfy
+                        EITHER of the two conditions:
+
+                        - path prefixed with `/foo` AND contains the header `version: v2`
+                        - path prefix of `/v2/foo`
+
+                        See the documentation for HTTPRouteMatch on how to specify multiple
+                        match conditions that should be ANDed together.
+
+                        If no matches are specified, the default is a prefix
+                        path match on "/", which has the effect of matching every
+                        HTTP request.
+
+                        Proxy or Load Balancer routing configuration generated from HTTPRoutes
+                        MUST prioritize matches based on the following criteria, continuing on
+                        ties. Across all rules specified on applicable Routes, precedence must be
+                        given to the match having:
+
+                        * "Exact" path match.
+                        * "Prefix" path match with largest number of characters.
+                        * Method match.
+                        * Largest number of header matches.
+                        * Largest number of query param matches.
+
+                        Note: The precedence of RegularExpression path matches are implementation-specific.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within an HTTPRoute, matching precedence MUST be granted
+                        to the FIRST matching rule (in list order) with a match meeting the above
+                        criteria.
+
+                        When no rules matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST be returned.
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                          \ value \"v1\"\n\n```"
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies HTTP request header matchers. Multiple match values are
+                              ANDed together, meaning, a request must match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+
+                                    When a header is repeated in an HTTP request, it is
+                                    implementation-specific behavior as to how this is represented.
+                                    Generally, proxies should follow the guidance from the RFC:
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                    processing a repeated header, with special handling for "Set-Cookie".
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the header.
+
+                                    Support: Core (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's documentation to
+                                    determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies HTTP method matcher.
+                              When specified, this route will be matched only if the request has the
+                              specified method.
+
+                              Support: Extended
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: |-
+                              Path specifies a HTTP request path matcher. If this field is not
+                              specified, a default prefix match on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: |-
+                                  Type specifies how to match against the path Value.
+
+                                  Support: Core (Exact, PathPrefix)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: |-
+                              QueryParams specifies HTTP query parameter matchers. Multiple match
+                              values are ANDed together, meaning, a request must match all the
+                              specified query parameters to select the route.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                query parameters.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP query param to be matched. This must be an
+                                    exact string match. (See
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+                                    If multiple entries specify equivalent query param names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST be ignored.
+
+                                    If a query param is repeated in an HTTP request, the behavior is
+                                    purposely left undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that implementations should
+                                    match against the first value of the param if the data plane supports it,
+                                    as this behavior is expected in other load balancing contexts outside of
+                                    the Gateway API.
+
+                                    Users SHOULD NOT route traffic based on repeated query params to guard
+                                    themselves against potential differences in the implementations.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the query parameter.
+
+                                    Support: Extended (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other
+                                    dialects of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |+
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maxmimum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+
+                              <gateway:experimental>
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          HTTPRoute provides a way to route HTTP requests. This includes the capability
+          to match requests by hostname, path, header, or query param. Filters can be
+          used to specify additional processing steps. Backends specify where matching
+          requests should be routed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames that should match against the HTTP Host
+                  header to select a HTTPRoute used to process the request. Implementations
+                  MUST ignore any port value specified in the HTTP Host header while
+                  performing a match and (absent of any applicable header modification
+                  configuration) MUST forward this header unmodified to the backend.
+
+                  Valid values for Hostnames are determined by RFC 1123 definition of a
+                  hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and HTTPRoute, there
+                  must be at least one intersecting hostname for the HTTPRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+                    all match. On the other hand, `example.com` and `test.example.net` would
+                    not match.
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+                  If both the Listener and HTTPRoute have specified hostnames, any
+                  HTTPRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  HTTPRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and HTTPRoute have specified hostnames, and none
+                  match with the criteria above, then the HTTPRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
+                  overlapping wildcard matching and exact matching hostnames), precedence must
+                  be given to rules from the HTTPRoute with the largest number of:
+
+                  * Characters in a matching non-wildcard hostname.
+                  * Characters in a matching hostname.
+
+                  If ties exist across multiple Routes, the matching precedence rules for
+                  HTTPRouteMatches takes over.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: |+
+                  Rules are a list of HTTP matchers, filters and actions.
+
+                items:
+                  description: |-
+                    HTTPRouteRule defines semantics for matching an HTTP request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive a 500 status code.
+
+                        See the HTTPBackendRef definition for the rules about what makes a single
+                        HTTPBackendRef invalid.
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive a 500 status code.
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic must receive a 500. Implementations may
+                        choose how that 50 percent is determined.
+
+                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
+                        implementations SHOULD return a 503 for requests to that backend instead.
+                        If an implementation chooses to do this, all of the above rules for 500 responses
+                        MUST also apply for responses that return a 503.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level should be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in HTTPRouteRule.)
+                            items:
+                              description: |-
+                                HTTPRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+                                    This filter can be used multiple times within the same rule.
+
+                                    Support: Implementation-specific
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |+
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+                                    Support: Extended
+
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+                                        Support: Extended for Kubernetes Service
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: |+
+                                        Fraction represents the fraction of requests that should be
+                                        mirrored to BackendRef.
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: |+
+                                        Percent represents the percentage of requests that should be
+                                        mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                        requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                        Only one of Fraction or Percent may be specified. If neither field
+                                        is specified, 100% of requests will be mirrored.
+
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                requestRedirect:
+                                  description: |-
+                                    RequestRedirect defines a schema for a filter that responds to the
+                                    request with an HTTP redirection.
+
+                                    Support: Core
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the hostname to be used in the value of the `Location`
+                                        header in the response.
+                                        When empty, the hostname in the `Host` header of the request is used.
+
+                                        Support: Core
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines parameters used to modify the path of the incoming request.
+                                        The modified path is then used to construct the `Location` header. When
+                                        empty, the request path is used as-is.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: |-
+                                        Port is the port to be used in the value of the `Location`
+                                        header in the response.
+
+                                        If no port is specified, the redirect port MUST be derived using the
+                                        following rules:
+
+                                        * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                          port associated with the redirect scheme. Specifically "http" to port 80
+                                          and "https" to port 443. If the redirect scheme does not have a
+                                          well-known port, the listener port of the Gateway SHOULD be used.
+                                        * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                          Listener port.
+
+                                        Implementations SHOULD NOT add the port number in the 'Location'
+                                        header in the following cases:
+
+                                        * A Location header that will use HTTP (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 80.
+                                        * A Location header that will use HTTPS (whether that is determined via
+                                          the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                        Support: Extended
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: |-
+                                        Scheme is the scheme to be used in the value of the `Location` header in
+                                        the response. When empty, the scheme of the request is used.
+
+                                        Scheme redirects can affect the port of the redirect, for more information,
+                                        refer to the documentation for the port field of this filter.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Extended
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: |-
+                                        StatusCode is the HTTP status code to be used in response.
+
+                                        Note that values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause a crash.
+
+                                        Unknown values here must result in the implementation setting the
+                                        Accepted Condition for the Route to `status: False`, with a
+                                        Reason of `UnsupportedValue`.
+
+                                        Support: Core
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |-
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations must support core filters.
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+                                    - Implementation-specific: Filters that are defined and supported by
+                                      specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` should be set to
+                                      "ExtensionRef" for custom filters.
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause a crash.
+
+                                    Unknown values here must result in the implementation setting the
+                                    Accepted Condition for the Route to `status: False`, with a
+                                    Reason of `UnsupportedValue`.
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  type: string
+                                urlRewrite:
+                                  description: |-
+                                    URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                                    Support: Extended
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the value to be used to replace the Host header value during
+                                        forwarding.
+
+                                        Support: Extended
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path defines a path rewrite.
+
+                                        Support: Extended
+                                      properties:
+                                        replaceFullPath:
+                                          description: |-
+                                            ReplaceFullPath specifies the value with which to replace the full path
+                                            of a request during a rewrite or redirect.
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: |-
+                                            ReplacePrefixMatch specifies the value with which to replace the prefix
+                                            match of a request during a rewrite or redirect. For example, a request
+                                            to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+                                            Note that this matches the behavior of the PathPrefix match type. This
+                                            matches full path elements. A path element refers to the list of labels
+                                            in the path split by the `/` separator. When specified, a trailing `/` is
+                                            ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                            match the prefix `/abc`, but the path `/abcd` would not.
+
+                                            ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                            Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                            the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                            Request Path | Prefix Match | Replace Prefix | Modified Path
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the type of path modifier. Additional types may be
+                                            added in a future release of the API.
+
+                                            Note that values may be added to this enum, implementations
+                                            must ensure that unknown values will not cause a crash.
+
+                                            Unknown values here must result in the implementation setting the
+                                            Accepted Condition for the Route to `status: False`, with a
+                                            Reason of `UnsupportedValue`.
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+                        Wherever possible, implementations SHOULD implement filters in the order
+                        they are specified.
+
+                        Implementations MAY choose to implement this ordering strictly, rejecting
+                        any combination or order of filters that can not be supported. If implementations
+                        choose a strict interpretation of filter ordering, they MUST clearly document
+                        that behavior.
+
+                        To reject an invalid combination or order of filters, implementations SHOULD
+                        consider the Route Rules with this configuration invalid. If all Route Rules
+                        in a Route are invalid, the entire Route would be considered invalid. If only
+                        a portion of Route Rules are invalid, implementations MUST set the
+                        "PartiallyInvalid" condition for the Route.
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+                        - ALL core filters MUST be supported by all implementations.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+                        All filters are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined. If an
+                        implementation can not support other combinations of filters, they must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+                        Support: Core
+                      items:
+                        description: |-
+                          HTTPRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. HTTPRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+                              This filter can be used multiple times within the same rule.
+
+                              Support: Implementation-specific
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |+
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+                              Support: Extended
+
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+                                  Support: Extended for Kubernetes Service
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: |+
+                                  Fraction represents the fraction of requests that should be
+                                  mirrored to BackendRef.
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: |+
+                                  Percent represents the percentage of requests that should be
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
+                                  requests) and its maximum value is 100 (indicating 100% of requests).
+
+                                  Only one of Fraction or Percent may be specified. If neither field
+                                  is specified, 100% of requests will be mirrored.
+
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          requestRedirect:
+                            description: |-
+                              RequestRedirect defines a schema for a filter that responds to the
+                              request with an HTTP redirection.
+
+                              Support: Core
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the hostname to be used in the value of the `Location`
+                                  header in the response.
+                                  When empty, the hostname in the `Host` header of the request is used.
+
+                                  Support: Core
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines parameters used to modify the path of the incoming request.
+                                  The modified path is then used to construct the `Location` header. When
+                                  empty, the request path is used as-is.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: |-
+                                  Port is the port to be used in the value of the `Location`
+                                  header in the response.
+
+                                  If no port is specified, the redirect port MUST be derived using the
+                                  following rules:
+
+                                  * If redirect scheme is not-empty, the redirect port MUST be the well-known
+                                    port associated with the redirect scheme. Specifically "http" to port 80
+                                    and "https" to port 443. If the redirect scheme does not have a
+                                    well-known port, the listener port of the Gateway SHOULD be used.
+                                  * If redirect scheme is empty, the redirect port MUST be the Gateway
+                                    Listener port.
+
+                                  Implementations SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases:
+
+                                  * A Location header that will use HTTP (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 80.
+                                  * A Location header that will use HTTPS (whether that is determined via
+                                    the Listener protocol or the Scheme field) _and_ use port 443.
+
+                                  Support: Extended
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: |-
+                                  Scheme is the scheme to be used in the value of the `Location` header in
+                                  the response. When empty, the scheme of the request is used.
+
+                                  Scheme redirects can affect the port of the redirect, for more information,
+                                  refer to the documentation for the port field of this filter.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Extended
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: |-
+                                  StatusCode is the HTTP status code to be used in response.
+
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a crash.
+
+                                  Unknown values here must result in the implementation setting the
+                                  Accepted Condition for the Route to `status: False`, with a
+                                  Reason of `UnsupportedValue`.
+
+                                  Support: Core
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |-
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations must support core filters.
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+                              - Implementation-specific: Filters that are defined and supported by
+                                specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` should be set to
+                                "ExtensionRef" for custom filters.
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+                              Note that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+
+                              Unknown values here must result in the implementation setting the
+                              Accepted Condition for the Route to `status: False`, with a
+                              Reason of `UnsupportedValue`.
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            type: string
+                          urlRewrite:
+                            description: |-
+                              URLRewrite defines a schema for a filter that modifies a request during forwarding.
+
+                              Support: Extended
+                            properties:
+                              hostname:
+                                description: |-
+                                  Hostname is the value to be used to replace the Host header value during
+                                  forwarding.
+
+                                  Support: Extended
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: |-
+                                  Path defines a path rewrite.
+
+                                  Support: Extended
+                                properties:
+                                  replaceFullPath:
+                                    description: |-
+                                      ReplaceFullPath specifies the value with which to replace the full path
+                                      of a request during a rewrite or redirect.
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: |-
+                                      ReplacePrefixMatch specifies the value with which to replace the prefix
+                                      match of a request during a rewrite or redirect. For example, a request
+                                      to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+                                      Note that this matches the behavior of the PathPrefix match type. This
+                                      matches full path elements. A path element refers to the list of labels
+                                      in the path split by the `/` separator. When specified, a trailing `/` is
+                                      ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+                                      match the prefix `/abc`, but the path `/abcd` would not.
+
+                                      ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+                                      the implementation setting the Accepted Condition for the Route to `status: False`.
+
+                                      Request Path | Prefix Match | Replace Prefix | Modified Path
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the type of path modifier. Additional types may be
+                                      added in a future release of the API.
+
+                                      Note that values may be added to this enum, implementations
+                                      must ensure that unknown values will not cause a crash.
+
+                                      Unknown values here must result in the implementation setting the
+                                      Accepted Condition for the Route to `status: False`, with a
+                                      Reason of `UnsupportedValue`.
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        HTTP requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+                        For example, take the following matches configuration:
+
+                        ```
+                        matches:
+                        - path:
+                            value: "/foo"
+                          headers:
+                          - name: "version"
+                            value: "v2"
+                        - path:
+                            value: "/v2/foo"
+                        ```
+
+                        For a request to match against this rule, a request must satisfy
+                        EITHER of the two conditions:
+
+                        - path prefixed with `/foo` AND contains the header `version: v2`
+                        - path prefix of `/v2/foo`
+
+                        See the documentation for HTTPRouteMatch on how to specify multiple
+                        match conditions that should be ANDed together.
+
+                        If no matches are specified, the default is a prefix
+                        path match on "/", which has the effect of matching every
+                        HTTP request.
+
+                        Proxy or Load Balancer routing configuration generated from HTTPRoutes
+                        MUST prioritize matches based on the following criteria, continuing on
+                        ties. Across all rules specified on applicable Routes, precedence must be
+                        given to the match having:
+
+                        * "Exact" path match.
+                        * "Prefix" path match with largest number of characters.
+                        * Method match.
+                        * Largest number of header matches.
+                        * Largest number of query param matches.
+
+                        Note: The precedence of RegularExpression path matches are implementation-specific.
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+                        If ties still exist within an HTTPRoute, matching precedence MUST be granted
+                        to the FIRST matching rule (in list order) with a match meeting the above
+                        criteria.
+
+                        When no rules matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST be returned.
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                          \ value \"v1\"\n\n```"
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies HTTP request header matchers. Multiple match values are
+                              ANDed together, meaning, a request must match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                    case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+
+                                    When a header is repeated in an HTTP request, it is
+                                    implementation-specific behavior as to how this is represented.
+                                    Generally, proxies should follow the guidance from the RFC:
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                    processing a repeated header, with special handling for "Set-Cookie".
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the header.
+
+                                    Support: Core (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's documentation to
+                                    determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies HTTP method matcher.
+                              When specified, this route will be matched only if the request has the
+                              specified method.
+
+                              Support: Extended
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: |-
+                              Path specifies a HTTP request path matcher. If this field is not
+                              specified, a default prefix match on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: |-
+                                  Type specifies how to match against the path Value.
+
+                                  Support: Core (Exact, PathPrefix)
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: |-
+                              QueryParams specifies HTTP query parameter matchers. Multiple match
+                              values are ANDed together, meaning, a request must match all the
+                              specified query parameters to select the route.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                query parameters.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP query param to be matched. This must be an
+                                    exact string match. (See
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+                                    If multiple entries specify equivalent query param names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST be ignored.
+
+                                    If a query param is repeated in an HTTP request, the behavior is
+                                    purposely left undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that implementations should
+                                    match against the first value of the param if the data plane supports it,
+                                    as this behavior is expected in other load balancing contexts outside of
+                                    the Gateway API.
+
+                                    Users SHOULD NOT route traffic based on repeated query params to guard
+                                    themselves against potential differences in the implementations.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: |-
+                                    Type specifies how to match against the value of the query parameter.
+
+                                    Support: Extended (Exact)
+
+                                    Support: Implementation-specific (RegularExpression)
+
+                                    Since RegularExpression QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX, PCRE or any other
+                                    dialects of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                    name:
+                      description: |
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    retry:
+                      description: |+
+                        Retry defines the configuration for when to retry an HTTP request.
+
+                        Support: Extended
+
+                      properties:
+                        attempts:
+                          description: |-
+                            Attempts specifies the maxmimum number of times an individual request
+                            from the gateway to a backend should be retried.
+
+                            If the maximum number of retries has been attempted without a successful
+                            response from the backend, the Gateway MUST return an error.
+
+                            When this field is unspecified, the number of times to attempt to retry
+                            a backend request is implementation-specific.
+
+                            Support: Extended
+                          type: integer
+                        backoff:
+                          description: |-
+                            Backoff specifies the minimum duration a Gateway should wait between
+                            retry attempts and is represented in Gateway API Duration formatting.
+
+                            For example, setting the `rules[].retry.backoff` field to the value
+                            `100ms` will cause a backend request to first be retried approximately
+                            100 milliseconds after timing out or receiving a response code configured
+                            to be retryable.
+
+                            An implementation MAY use an exponential or alternative backoff strategy
+                            for subsequent retry attempts, MAY cap the maximum backoff duration to
+                            some amount greater than the specified minimum, and MAY add arbitrary
+                            jitter to stagger requests, as long as unsuccessful backend requests are
+                            not retried before the configured minimum duration.
+
+                            If a Request timeout (`rules[].timeouts.request`) is configured on the
+                            route, the entire duration of the initial request and any retry attempts
+                            MUST not exceed the Request timeout duration. If any retry attempts are
+                            still in progress when the Request timeout duration has been reached,
+                            these SHOULD be canceled if possible and the Gateway MUST immediately
+                            return a timeout error.
+
+                            If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                            configured on the route, any retry attempts which reach the configured
+                            BackendRequest timeout duration without a response SHOULD be canceled if
+                            possible and the Gateway should wait for at least the specified backoff
+                            duration before attempting to retry the backend request again.
+
+                            If a BackendRequest timeout is _not_ configured on the route, retry
+                            attempts MAY time out after an implementation default duration, or MAY
+                            remain pending until a configured Request timeout or implementation
+                            default duration for total request time is reached.
+
+                            When this field is unspecified, the time to wait between retry attempts
+                            is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        codes:
+                          description: |-
+                            Codes defines the HTTP response status codes for which a backend request
+                            should be retried.
+
+                            Support: Extended
+                          items:
+                            description: |-
+                              HTTPRouteRetryStatusCode defines an HTTP response status code for
+                              which a backend request should be retried.
+
+                              Implementations MUST support the following status codes as retryable:
+
+                              * 500
+                              * 502
+                              * 503
+                              * 504
+
+                              Implementations MAY support specifying additional discrete values in the
+                              500-599 range.
+
+                              Implementations MAY support specifying discrete values in the 400-499 range,
+                              which are often inadvisable to retry.
+
+                              <gateway:experimental>
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          type: array
+                      type: object
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+                        Support: Extended
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+                                Support: Core for "Session" type
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+                            Support: Core for "Cookie" type
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                          || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                type: array
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    shortNames:
+    - refgrant
+    singular: referencegrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ReferenceGrant identifies kinds of resources in other namespaces that are
+          trusted to reference the specified kinds of resources in the same namespace
+          as the policy.
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+          Additional Reference Grants can be used to add to the set of trusted
+          sources of inbound references for the namespace they are defined within.
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+          Gateway-route attachment) require a ReferenceGrant.
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+          which cross-namespace object references are permitted. Implementations that
+          support ReferenceGrant MUST NOT permit cross-namespace references which have
+          no grant, and MUST respond to the removal of a grant by revoking the access
+          that the grant allowed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: |-
+                  From describes the trusted namespaces and kinds that can reference the
+                  resources described in "To". Each entry in this list MUST be considered
+                  to be an additional place that references can be valid from, or to put
+                  this another way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field.
+
+                        When used to permit a SecretObjectReference:
+
+                        * Gateway
+
+                        When used to permit a BackendObjectReference:
+
+                        * GRPCRoute
+                        * HTTPRoute
+                        * TCPRoute
+                        * TLSRoute
+                        * UDPRoute
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              to:
+                description: |-
+                  To describes the resources that may be referenced by the resources
+                  described in "From". Each entry in this list MUST be considered to be an
+                  additional place that references can be valid to, or to put this another
+                  way, entries MUST be combined using OR.
+
+                  Support: Core
+                items:
+                  description: |-
+                    ReferenceGrantTo describes what Kinds are allowed as targets of the
+                    references.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field:
+
+                        * Secret when used to permit a SecretObjectReference
+                        * Service when used to permit a BackendObjectReference
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent. When unspecified, this policy
+                        refers to all resources of the specified Group and Kind in the local
+                        namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TCPRoute provides a way to route TCP requests. When combined with a Gateway
+          listener, it can be used to forward connections on the port specified by the
+          listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of TCP matchers and actions.
+
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Connection rejections must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI names that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of TLS matchers and actions.
+
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status code.
+                        Request rejections must respect weight; if an invalid backend is
+                        requested to have 80% of requests, then 80% of requests must be rejected
+                        instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+          listener, it can be used to forward traffic on the port specified by the
+          listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: |+
+                  Rules are a list of UDP matchers and actions.
+
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Packet drops must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        the packets, then 80% of packets must be dropped instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          <gateway:experimental:description>
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+                          </gateway:experimental:description>
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/charts/contour-crds/templates/contour-crds.yaml
+++ b/charts/contour-crds/templates/contour-crds.yaml
@@ -1,0 +1,8799 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: contourconfigurations.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourConfiguration
+    listKind: ContourConfigurationList
+    plural: contourconfigurations
+    shortNames:
+    - contourconfig
+    singular: contourconfiguration
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContourConfiguration is the schema for a Contour instance.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ContourConfigurationSpec represents a configuration of a Contour controller.
+              It contains most of all the options that can be customized, the
+              other remaining options being command line flags.
+            properties:
+              debug:
+                description: |-
+                  Debug contains parameters to enable debug logging
+                  and debug interfaces inside Contour.
+                properties:
+                  address:
+                    description: |-
+                      Defines the Contour debug address interface.
+                      Contour's default is "127.0.0.1".
+                    type: string
+                  port:
+                    description: |-
+                      Defines the Contour debug address port.
+                      Contour's default is 6060.
+                    type: integer
+                type: object
+              enableExternalNameService:
+                description: |-
+                  EnableExternalNameService allows processing of ExternalNameServices
+                  Contour's default is false for security reasons.
+                type: boolean
+              envoy:
+                description: |-
+                  Envoy contains parameters for Envoy as well
+                  as how to optionally configure a managed Envoy fleet.
+                properties:
+                  clientCertificate:
+                    description: |-
+                      ClientCertificate defines the namespace/name of the Kubernetes
+                      secret containing the client certificate and private key
+                      to be used when establishing TLS connection to upstream
+                      cluster.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  cluster:
+                    description: |-
+                      Cluster holds various configurable Envoy cluster values that can
+                      be set in the config file.
+                    properties:
+                      circuitBreakers:
+                        description: |-
+                          GlobalCircuitBreakerDefaults specifies default circuit breaker budget across all services.
+                          If defined, this will be used as the default for all services.
+                        properties:
+                          maxConnections:
+                            description: The maximum number of connections that a
+                              single Envoy instance allows to the Kubernetes Service;
+                              defaults to 1024.
+                            format: int32
+                            type: integer
+                          maxPendingRequests:
+                            description: The maximum number of pending requests that
+                              a single Envoy instance allows to the Kubernetes Service;
+                              defaults to 1024.
+                            format: int32
+                            type: integer
+                          maxRequests:
+                            description: The maximum parallel requests a single Envoy
+                              instance allows to the Kubernetes Service; defaults
+                              to 1024
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            description: The maximum number of parallel retries a
+                              single Envoy instance allows to the Kubernetes Service;
+                              defaults to 3.
+                            format: int32
+                            type: integer
+                          perHostMaxConnections:
+                            description: |-
+                              PerHostMaxConnections is the maximum number of connections
+                              that Envoy will allow to each individual host in a cluster.
+                            format: int32
+                            type: integer
+                        type: object
+                      dnsLookupFamily:
+                        description: |-
+                          DNSLookupFamily defines how external names are looked up
+                          When configured as V4, the DNS resolver will only perform a lookup
+                          for addresses in the IPv4 family. If V6 is configured, the DNS resolver
+                          will only perform a lookup for addresses in the IPv6 family.
+                          If AUTO is configured, the DNS resolver will first perform a lookup
+                          for addresses in the IPv6 family and fallback to a lookup for addresses
+                          in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+                          both IPv4 and IPv6 families, and return all resolved addresses.
+                          When this is used, Happy Eyeballs will be enabled for upstream connections.
+                          Refer to Happy Eyeballs Support for more information.
+                          Note: This only applies to externalName clusters.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information.
+                          Values: `auto` (default), `v4`, `v6`, `all`.
+                          Other values will produce an error.
+                        type: string
+                      maxRequestsPerConnection:
+                        description: |-
+                          Defines the maximum requests for upstream connections. If not specified, there is no limit.
+                          see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                          for more information.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      per-connection-buffer-limit-bytes:
+                        description: |-
+                          Defines the soft limit on size of the cluster’s new connection read and write buffers in bytes.
+                          If unspecified, an implementation defined default is applied (1MiB).
+                          see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-per-connection-buffer-limit-bytes
+                          for more information.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      upstreamTLS:
+                        description: UpstreamTLS contains the TLS policy parameters
+                          for upstream connections
+                        properties:
+                          cipherSuites:
+                            description: |-
+                              CipherSuites defines the TLS ciphers to be supported by Envoy TLS
+                              listeners when negotiating TLS 1.2. Ciphers are validated against the
+                              set that Envoy supports by default. This parameter should only be used
+                              by advanced users. Note that these will be ignored when TLS 1.3 is in
+                              use.
+                              This field is optional; when it is undefined, a Contour-managed ciphersuite list
+                              will be used, which may be updated to keep it secure.
+                              Contour's default list is:
+                                - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                - "ECDHE-RSA-AES256-GCM-SHA384"
+                              Ciphers provided are validated against the following list:
+                                - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                - "ECDHE-ECDSA-AES128-GCM-SHA256"
+                                - "ECDHE-RSA-AES128-GCM-SHA256"
+                                - "ECDHE-ECDSA-AES128-SHA"
+                                - "ECDHE-RSA-AES128-SHA"
+                                - "AES128-GCM-SHA256"
+                                - "AES128-SHA"
+                                - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                - "ECDHE-RSA-AES256-GCM-SHA384"
+                                - "ECDHE-ECDSA-AES256-SHA"
+                                - "ECDHE-RSA-AES256-SHA"
+                                - "AES256-GCM-SHA384"
+                                - "AES256-SHA"
+                              Contour recommends leaving this undefined unless you are sure you must.
+                              See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                              Note: This list is a superset of what is valid for stock Envoy builds and those using BoringSSL FIPS.
+                            items:
+                              type: string
+                            type: array
+                          maximumProtocolVersion:
+                            description: |-
+                              MaximumProtocolVersion is the maximum TLS version this vhost should
+                              negotiate.
+                              Values: `1.2`, `1.3`(default).
+                              Other values will produce an error.
+                            type: string
+                          minimumProtocolVersion:
+                            description: |-
+                              MinimumProtocolVersion is the minimum TLS version this vhost should
+                              negotiate.
+                              Values: `1.2` (default), `1.3`.
+                              Other values will produce an error.
+                            type: string
+                        type: object
+                    type: object
+                  defaultHTTPVersions:
+                    description: |-
+                      DefaultHTTPVersions defines the default set of HTTPS
+                      versions the proxy should accept. HTTP versions are
+                      strings of the form "HTTP/xx". Supported versions are
+                      "HTTP/1.1" and "HTTP/2".
+                      Values: `HTTP/1.1`, `HTTP/2` (default: both).
+                      Other values will produce an error.
+                    items:
+                      description: HTTPVersionType is the name of a supported HTTP
+                        version.
+                      type: string
+                    type: array
+                  health:
+                    description: |-
+                      Health defines the endpoint Envoy uses to serve health checks.
+                      Contour's default is { address: "0.0.0.0", port: 8002 }.
+                    properties:
+                      address:
+                        description: Defines the health address interface.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the health port.
+                        type: integer
+                    type: object
+                  http:
+                    description: |-
+                      Defines the HTTP Listener for Envoy.
+                      Contour's default is { address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout" }.
+                    properties:
+                      accessLog:
+                        description: AccessLog defines where Envoy logs are outputted
+                          for this listener.
+                        type: string
+                      address:
+                        description: Defines an Envoy Listener Address.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines an Envoy listener Port.
+                        type: integer
+                    type: object
+                  https:
+                    description: |-
+                      Defines the HTTPS Listener for Envoy.
+                      Contour's default is { address: "0.0.0.0", port: 8443, accessLog: "/dev/stdout" }.
+                    properties:
+                      accessLog:
+                        description: AccessLog defines where Envoy logs are outputted
+                          for this listener.
+                        type: string
+                      address:
+                        description: Defines an Envoy Listener Address.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines an Envoy listener Port.
+                        type: integer
+                    type: object
+                  listener:
+                    description: Listener hold various configurable Envoy listener
+                      values.
+                    properties:
+                      compression:
+                        description: Compression defines configuration related to
+                          compression in the default HTTP Listener filters.
+                        properties:
+                          algorithm:
+                            description: |-
+                              Algorithm selects the response compression type applied in the compression HTTP filter of the default Listener filters.
+                              Values: `gzip` (default), `brotli`, `zstd`, `disabled`.
+                              Setting this to `disabled` will make Envoy skip "Accept-Encoding: gzip,deflate" request header and always return uncompressed response.
+                            enum:
+                            - gzip
+                            - brotli
+                            - zstd
+                            - disabled
+                            type: string
+                        type: object
+                      connectionBalancer:
+                        description: |-
+                          ConnectionBalancer. If the value is exact, the listener will use the exact connection balancer
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                          for more information.
+                          Values: (empty string): use the default ConnectionBalancer, `exact`: use the Exact ConnectionBalancer.
+                          Other values will produce an error.
+                        type: string
+                      disableAllowChunkedLength:
+                        description: |-
+                          DisableAllowChunkedLength disables the RFC-compliant Envoy behavior to
+                          strip the "Content-Length" header if "Transfer-Encoding: chunked" is
+                          also set. This is an emergency off-switch to revert back to Envoy's
+                          default behavior in case of failures. Please file an issue if failures
+                          are encountered.
+                          See: https://github.com/projectcontour/contour/issues/3221
+                          Contour's default is false.
+                        type: boolean
+                      disableMergeSlashes:
+                        description: |-
+                          DisableMergeSlashes disables Envoy's non-standard merge_slashes path transformation option
+                          which strips duplicate slashes from request URL paths.
+                          Contour's default is false.
+                        type: boolean
+                      httpMaxConcurrentStreams:
+                        description: |-
+                          Defines the value for SETTINGS_MAX_CONCURRENT_STREAMS Envoy will advertise in the
+                          SETTINGS frame in HTTP/2 connections and the limit for concurrent streams allowed
+                          for a peer on a single HTTP/2 connection. It is recommended to not set this lower
+                          than 100 but this field can be used to bound resource usage by HTTP/2 connections
+                          and mitigate attacks like CVE-2023-44487. The default value when this is not set is
+                          unlimited.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      maxConnectionsPerListener:
+                        description: |-
+                          Defines the limit on number of active connections to a listener. The limit is applied
+                          per listener. The default value when this is not set is unlimited.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      maxRequestsPerConnection:
+                        description: |-
+                          Defines the maximum requests for downstream connections. If not specified, there is no limit.
+                          see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                          for more information.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      maxRequestsPerIOCycle:
+                        description: |-
+                          Defines the limit on number of HTTP requests that Envoy will process from a single
+                          connection in a single I/O cycle. Requests over this limit are processed in subsequent
+                          I/O cycles. Can be used as a mitigation for CVE-2023-44487 when abusive traffic is
+                          detected. Configures the http.max_requests_per_io_cycle Envoy runtime setting. The default
+                          value when this is not set is no limit.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      per-connection-buffer-limit-bytes:
+                        description: |-
+                          Defines the soft limit on size of the listener’s new connection read and write buffers in bytes.
+                          If unspecified, an implementation defined default is applied (1MiB).
+                          see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes
+                          for more information.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      serverHeaderTransformation:
+                        description: |-
+                          Defines the action to be applied to the Server header on the response path.
+                          When configured as overwrite, overwrites any Server header with "envoy".
+                          When configured as append_if_absent, if a Server header is present, pass it through, otherwise set it to "envoy".
+                          When configured as pass_through, pass through the value of the Server header, and do not append a header if none is present.
+                          Values: `overwrite` (default), `append_if_absent`, `pass_through`
+                          Other values will produce an error.
+                          Contour's default is overwrite.
+                        type: string
+                      socketOptions:
+                        description: |-
+                          SocketOptions defines configurable socket options for the listeners.
+                          Single set of options are applied to all listeners.
+                        properties:
+                          tos:
+                            description: |-
+                              Defines the value for IPv4 TOS field (including 6 bit DSCP field) for IP packets originating from Envoy listeners.
+                              Single value is applied to all listeners.
+                              If listeners are bound to IPv6-only addresses, setting this option will cause an error.
+                            format: int32
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          trafficClass:
+                            description: |-
+                              Defines the value for IPv6 Traffic Class field (including 6 bit DSCP field) for IP packets originating from the Envoy listeners.
+                              Single value is applied to all listeners.
+                              If listeners are bound to IPv4-only addresses, setting this option will cause an error.
+                            format: int32
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                        type: object
+                      tls:
+                        description: TLS holds various configurable Envoy TLS listener
+                          values.
+                        properties:
+                          cipherSuites:
+                            description: |-
+                              CipherSuites defines the TLS ciphers to be supported by Envoy TLS
+                              listeners when negotiating TLS 1.2. Ciphers are validated against the
+                              set that Envoy supports by default. This parameter should only be used
+                              by advanced users. Note that these will be ignored when TLS 1.3 is in
+                              use.
+                              This field is optional; when it is undefined, a Contour-managed ciphersuite list
+                              will be used, which may be updated to keep it secure.
+                              Contour's default list is:
+                                - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                - "ECDHE-RSA-AES256-GCM-SHA384"
+                              Ciphers provided are validated against the following list:
+                                - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                - "ECDHE-ECDSA-AES128-GCM-SHA256"
+                                - "ECDHE-RSA-AES128-GCM-SHA256"
+                                - "ECDHE-ECDSA-AES128-SHA"
+                                - "ECDHE-RSA-AES128-SHA"
+                                - "AES128-GCM-SHA256"
+                                - "AES128-SHA"
+                                - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                - "ECDHE-RSA-AES256-GCM-SHA384"
+                                - "ECDHE-ECDSA-AES256-SHA"
+                                - "ECDHE-RSA-AES256-SHA"
+                                - "AES256-GCM-SHA384"
+                                - "AES256-SHA"
+                              Contour recommends leaving this undefined unless you are sure you must.
+                              See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                              Note: This list is a superset of what is valid for stock Envoy builds and those using BoringSSL FIPS.
+                            items:
+                              type: string
+                            type: array
+                          maximumProtocolVersion:
+                            description: |-
+                              MaximumProtocolVersion is the maximum TLS version this vhost should
+                              negotiate.
+                              Values: `1.2`, `1.3`(default).
+                              Other values will produce an error.
+                            type: string
+                          minimumProtocolVersion:
+                            description: |-
+                              MinimumProtocolVersion is the minimum TLS version this vhost should
+                              negotiate.
+                              Values: `1.2` (default), `1.3`.
+                              Other values will produce an error.
+                            type: string
+                        type: object
+                      useProxyProtocol:
+                        description: |-
+                          Use PROXY protocol for all listeners.
+                          Contour's default is false.
+                        type: boolean
+                    type: object
+                  logging:
+                    description: Logging defines how Envoy's logs can be configured.
+                    properties:
+                      accessLogFormat:
+                        description: |-
+                          AccessLogFormat sets the global access log format.
+                          Values: `envoy` (default), `json`.
+                          Other values will produce an error.
+                        type: string
+                      accessLogFormatString:
+                        description: |-
+                          AccessLogFormatString sets the access log format when format is set to `envoy`.
+                          When empty, Envoy's default format is used.
+                        type: string
+                      accessLogJSONFields:
+                        description: |-
+                          AccessLogJSONFields sets the fields that JSON logging will
+                          output when AccessLogFormat is json.
+                        items:
+                          type: string
+                        type: array
+                      accessLogLevel:
+                        description: |-
+                          AccessLogLevel sets the verbosity level of the access log.
+                          Values: `info` (default, all requests are logged), `error` (all non-success requests, i.e. 300+ response code, are logged), `critical` (all 5xx requests are logged) and `disabled`.
+                          Other values will produce an error.
+                        type: string
+                    type: object
+                  metrics:
+                    description: |-
+                      Metrics defines the endpoint Envoy uses to serve metrics.
+                      Contour's default is { address: "0.0.0.0", port: 8002 }.
+                    properties:
+                      address:
+                        description: Defines the metrics address interface.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the metrics port.
+                        type: integer
+                      tls:
+                        description: |-
+                          TLS holds TLS file config details.
+                          Metrics and health endpoints cannot have same port number when metrics is served over HTTPS.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        type: object
+                    type: object
+                  network:
+                    description: Network holds various configurable Envoy network
+                      values.
+                    properties:
+                      adminPort:
+                        description: |-
+                          Configure the port used to access the Envoy Admin interface.
+                          If configured to port "0" then the admin interface is disabled.
+                          Contour's default is 9001.
+                        type: integer
+                      numTrustedHops:
+                        description: |-
+                          XffNumTrustedHops defines the number of additional ingress proxy hops from the
+                          right side of the x-forwarded-for HTTP header to trust when determining the origin
+                          client’s IP address.
+                          See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                          for more information.
+                          Contour's default is 0.
+                        format: int32
+                        type: integer
+                      stripTrailingHostDot:
+                        description: |-
+                          EnvoyStripTrailingHostDot defines if trailing dot of the host should be removed from host/authority header
+                          before any processing of request by HTTP filters or routing. This
+                          affects the upstream host header. Without setting this option to true, incoming
+                          requests with host example.com. will not match against route with domains
+                          match set to example.com.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=strip_trailing_host_dot
+                          for more information.
+                          Contour's default is false.
+                        type: boolean
+                    type: object
+                  omEnforcedHealth:
+                    description: |-
+                      OMEnforcedHealth defines the endpoint Envoy uses to serve health checks with
+                      the envoy overload manager actions, such as global connection limits, enforced.
+                      The configured values must be different from the endpoints
+                      configured by [EnvoyConfig.Metrics] and [EnvoyConfig.Health]
+                      This is disabled by default
+                    properties:
+                      address:
+                        description: Defines the health address interface.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the health port.
+                        type: integer
+                    type: object
+                  service:
+                    description: |-
+                      Service holds Envoy service parameters for setting Ingress status.
+                      Contour's default is { namespace: "projectcontour", name: "envoy" }.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  timeouts:
+                    description: |-
+                      Timeouts holds various configurable timeouts that can
+                      be set in the config file.
+                    properties:
+                      connectTimeout:
+                        description: |-
+                          ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
+                          If not set, a default value of 2 seconds will be used.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                          for more information.
+                        type: string
+                      connectionIdleTimeout:
+                        description: |-
+                          ConnectionIdleTimeout defines how long the proxy should wait while there are
+                          no active requests (for HTTP/1.1) or streams (for HTTP/2) before terminating
+                          an HTTP connection. Set to "infinity" to disable the timeout entirely.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                          for more information.
+                        type: string
+                      connectionShutdownGracePeriod:
+                        description: |-
+                          ConnectionShutdownGracePeriod defines how long the proxy will wait between sending an
+                          initial GOAWAY frame and a second, final GOAWAY frame when terminating an HTTP/2 connection.
+                          During this grace period, the proxy will continue to respond to new streams. After the final
+                          GOAWAY frame has been sent, the proxy will refuse new streams.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                          for more information.
+                        type: string
+                      delayedCloseTimeout:
+                        description: |-
+                          DelayedCloseTimeout defines how long envoy will wait, once connection
+                          close processing has been initiated, for the downstream peer to close
+                          the connection before Envoy closes the socket associated with the connection.
+                          Setting this timeout to 'infinity' will disable it, equivalent to setting it to '0'
+                          in Envoy. Leaving it unset will result in the Envoy default value being used.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                          for more information.
+                        type: string
+                      maxConnectionDuration:
+                        description: |-
+                          MaxConnectionDuration defines the maximum period of time after an HTTP connection
+                          has been established from the client to the proxy before it is closed by the proxy,
+                          regardless of whether there has been activity or not. Omit or set to "infinity" for
+                          no max duration.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                          for more information.
+                        type: string
+                      requestTimeout:
+                        description: |-
+                          RequestTimeout sets the client request timeout globally for Contour. Note that
+                          this is a timeout for the entire request, not an idle timeout. Omit or set to
+                          "infinity" to disable the timeout entirely.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                          for more information.
+                        type: string
+                      streamIdleTimeout:
+                        description: |-
+                          StreamIdleTimeout defines how long the proxy should wait while there is no
+                          request activity (for HTTP/1.1) or stream activity (for HTTP/2) before
+                          terminating the HTTP request or stream. Set to "infinity" to disable the
+                          timeout entirely.
+                          See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                          for more information.
+                        type: string
+                    type: object
+                type: object
+              featureFlags:
+                description: FeatureFlags defines toggle to enable new contour features.
+                items:
+                  type: string
+                type: array
+              gateway:
+                description: |-
+                  Gateway contains parameters for the gateway-api Gateway that Contour
+                  is configured to serve traffic.
+                properties:
+                  gatewayRef:
+                    description: |-
+                      GatewayRef defines the specific Gateway that this Contour
+                      instance corresponds to.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                required:
+                - gatewayRef
+                type: object
+              globalExtAuth:
+                description: |-
+                  GlobalExternalAuthorization allows envoys external authorization filter
+                  to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: |-
+                      AuthPolicy sets a default authorization policy for client requests.
+                      This policy will be used unless overridden by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Context is a set of key/value pairs that are sent to the
+                          authentication server in the check request. If a context
+                          is provided at an enclosing scope, the entries are merged
+                          such that the inner scope overrides matching keys from the
+                          outer scope.
+                        type: object
+                      disabled:
+                        description: |-
+                          When true, this field disables client request authentication
+                          for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: |-
+                          API version of the referent.
+                          If this field is not specified, the default "projectcontour.io/v1alpha1" will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          If this field is not specifies, the namespace of the resource that targets the referent will be used.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: |-
+                      If FailOpen is true, the client request is forwarded to the upstream service
+                      even if the authorization server fails to respond. This field should not be
+                      set in most cases. It is intended for use only while migrating applications
+                      from internal authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: |-
+                      ResponseTimeout configures maximum time to wait for a check response from the authorization server.
+                      Timeout durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
+              health:
+                description: |-
+                  Health defines the endpoints Contour uses to serve health checks.
+                  Contour's default is { address: "0.0.0.0", port: 8000 }.
+                properties:
+                  address:
+                    description: Defines the health address interface.
+                    minLength: 1
+                    type: string
+                  port:
+                    description: Defines the health port.
+                    type: integer
+                type: object
+              httpproxy:
+                description: HTTPProxy defines parameters on HTTPProxy.
+                properties:
+                  disablePermitInsecure:
+                    description: |-
+                      DisablePermitInsecure disables the use of the
+                      permitInsecure field in HTTPProxy.
+                      Contour's default is false.
+                    type: boolean
+                  fallbackCertificate:
+                    description: |-
+                      FallbackCertificate defines the namespace/name of the Kubernetes secret to
+                      use as fallback when a non-SNI request is received.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  rootNamespaces:
+                    description: Restrict Contour to searching these namespaces for
+                      root ingress routes.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              ingress:
+                description: Ingress contains parameters for ingress options.
+                properties:
+                  classNames:
+                    description: Ingress Class Names Contour should use.
+                    items:
+                      type: string
+                    type: array
+                  statusAddress:
+                    description: Address to set in Ingress object status.
+                    type: string
+                type: object
+              metrics:
+                description: |-
+                  Metrics defines the endpoint Contour uses to serve metrics.
+                  Contour's default is { address: "0.0.0.0", port: 8000 }.
+                properties:
+                  address:
+                    description: Defines the metrics address interface.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  port:
+                    description: Defines the metrics port.
+                    type: integer
+                  tls:
+                    description: |-
+                      TLS holds TLS file config details.
+                      Metrics and health endpoints cannot have same port number when metrics is served over HTTPS.
+                    properties:
+                      caFile:
+                        description: CA filename.
+                        type: string
+                      certFile:
+                        description: Client certificate filename.
+                        type: string
+                      keyFile:
+                        description: Client key filename.
+                        type: string
+                    type: object
+                type: object
+              policy:
+                description: Policy specifies default policy applied if not overridden
+                  by the user
+                properties:
+                  applyToIngress:
+                    description: |-
+                      ApplyToIngress determines if the Policies will apply to ingress objects
+                      Contour's default is false.
+                    type: boolean
+                  requestHeaders:
+                    description: RequestHeadersPolicy defines the request headers
+                      set/removed on all routes
+                    properties:
+                      remove:
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  responseHeaders:
+                    description: ResponseHeadersPolicy defines the response headers
+                      set/removed on all routes
+                    properties:
+                      remove:
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                type: object
+              rateLimitService:
+                description: |-
+                  RateLimitService optionally holds properties of the Rate Limit Service
+                  to be used for global rate limiting.
+                properties:
+                  defaultGlobalRateLimitPolicy:
+                    description: |-
+                      DefaultGlobalRateLimitPolicy allows setting a default global rate limit policy for every HTTPProxy.
+                      HTTPProxy can overwrite this configuration.
+                    properties:
+                      descriptors:
+                        description: |-
+                          Descriptors defines the list of descriptors that will
+                          be generated and sent to the rate limit service. Each
+                          descriptor contains 1+ key-value pair entries.
+                        items:
+                          description: RateLimitDescriptor defines a list of key-value
+                            pair generators.
+                          properties:
+                            entries:
+                              description: Entries is the list of key-value pair generators.
+                              items:
+                                description: |-
+                                  RateLimitDescriptorEntry is a key-value pair generator. Exactly
+                                  one field on this struct must be non-nil.
+                                properties:
+                                  genericKey:
+                                    description: GenericKey defines a descriptor entry
+                                      with a static key and value.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          Key defines the key of the descriptor entry. If not set, the
+                                          key is set to "generic_key".
+                                        type: string
+                                      value:
+                                        description: Value defines the value of the
+                                          descriptor entry.
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - value
+                                    type: object
+                                  remoteAddress:
+                                    description: |-
+                                      RemoteAddress defines a descriptor entry with a key of "remote_address"
+                                      and a value equal to the client's IP address (from x-forwarded-for).
+                                    type: object
+                                  requestHeader:
+                                    description: |-
+                                      RequestHeader defines a descriptor entry that's populated only if
+                                      a given header is present on the request. The descriptor key is static,
+                                      and the descriptor value is equal to the value of the header.
+                                    properties:
+                                      descriptorKey:
+                                        description: DescriptorKey defines the key
+                                          to use on the descriptor entry.
+                                        minLength: 1
+                                        type: string
+                                      headerName:
+                                        description: HeaderName defines the name of
+                                          the header to look for on the request.
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - descriptorKey
+                                    - headerName
+                                    type: object
+                                  requestHeaderValueMatch:
+                                    description: |-
+                                      RequestHeaderValueMatch defines a descriptor entry that's populated
+                                      if the request's headers match a set of 1+ match criteria. The
+                                      descriptor key is "header_match", and the descriptor value is static.
+                                    properties:
+                                      expectMatch:
+                                        default: true
+                                        description: |-
+                                          ExpectMatch defines whether the request must positively match the match
+                                          criteria in order to generate a descriptor entry (i.e. true), or not
+                                          match the match criteria in order to generate a descriptor entry (i.e. false).
+                                          The default is true.
+                                        type: boolean
+                                      headers:
+                                        description: |-
+                                          Headers is a list of 1+ match criteria to apply against the request
+                                          to determine whether to populate the descriptor entry or not.
+                                        items:
+                                          description: |-
+                                            HeaderMatchCondition specifies how to conditionally match against HTTP
+                                            headers. The Name field is required, only one of Present, NotPresent,
+                                            Contains, NotContains, Exact, NotExact and Regex can be set.
+                                            For negative matching rules only (e.g. NotContains or NotExact) you can set
+                                            TreatMissingAsEmpty.
+                                            IgnoreCase has no effect for Regex.
+                                          properties:
+                                            contains:
+                                              description: |-
+                                                Contains specifies a substring that must be present in
+                                                the header value.
+                                              type: string
+                                            exact:
+                                              description: Exact specifies a string
+                                                that the header value must be equal
+                                                to.
+                                              type: string
+                                            ignoreCase:
+                                              description: |-
+                                                IgnoreCase specifies that string matching should be case insensitive.
+                                                Note that this has no effect on the Regex parameter.
+                                              type: boolean
+                                            name:
+                                              description: |-
+                                                Name is the name of the header to match against. Name is required.
+                                                Header names are case insensitive.
+                                              type: string
+                                            notcontains:
+                                              description: |-
+                                                NotContains specifies a substring that must not be present
+                                                in the header value.
+                                              type: string
+                                            notexact:
+                                              description: |-
+                                                NoExact specifies a string that the header value must not be
+                                                equal to. The condition is true if the header has any other value.
+                                              type: string
+                                            notpresent:
+                                              description: |-
+                                                NotPresent specifies that condition is true when the named header
+                                                is not present. Note that setting NotPresent to false does not
+                                                make the condition true if the named header is present.
+                                              type: boolean
+                                            present:
+                                              description: |-
+                                                Present specifies that condition is true when the named header
+                                                is present, regardless of its value. Note that setting Present
+                                                to false does not make the condition true if the named header
+                                                is absent.
+                                              type: boolean
+                                            regex:
+                                              description: |-
+                                                Regex specifies a regular expression pattern that must match the header
+                                                value.
+                                              type: string
+                                            treatMissingAsEmpty:
+                                              description: |-
+                                                TreatMissingAsEmpty specifies if the header match rule specified header
+                                                does not exist, this header value will be treated as empty. Defaults to false.
+                                                Unlike the underlying Envoy implementation this is **only** supported for
+                                                negative matches (e.g. NotContains, NotExact).
+                                              type: boolean
+                                          required:
+                                          - name
+                                          type: object
+                                        minItems: 1
+                                        type: array
+                                      value:
+                                        description: Value defines the value of the
+                                          descriptor entry.
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - value
+                                    type: object
+                                type: object
+                              minItems: 1
+                              type: array
+                          required:
+                          - entries
+                          type: object
+                        minItems: 1
+                        type: array
+                      disabled:
+                        description: |-
+                          Disabled configures the HTTPProxy to not use
+                          the default global rate limit policy defined by the Contour configuration.
+                        type: boolean
+                    type: object
+                  domain:
+                    description: Domain is passed to the Rate Limit Service.
+                    type: string
+                  enableResourceExhaustedCode:
+                    description: |-
+                      EnableResourceExhaustedCode enables translating error code 429 to
+                      grpc code RESOURCE_EXHAUSTED. When disabled it's translated to UNAVAILABLE
+                    type: boolean
+                  enableXRateLimitHeaders:
+                    description: |-
+                      EnableXRateLimitHeaders defines whether to include the X-RateLimit
+                      headers X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset
+                      (as defined by the IETF Internet-Draft linked below), on responses
+                      to clients when the Rate Limit Service is consulted for a request.
+                      ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html
+                    type: boolean
+                  extensionService:
+                    description: ExtensionService identifies the extension service
+                      defining the RLS.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  failOpen:
+                    description: |-
+                      FailOpen defines whether to allow requests to proceed when the
+                      Rate Limit Service fails to respond with a valid rate limit
+                      decision within the timeout defined on the extension service.
+                    type: boolean
+                required:
+                - extensionService
+                type: object
+              tracing:
+                description: Tracing defines properties for exporting trace data to
+                  OpenTelemetry.
+                properties:
+                  customTags:
+                    description: CustomTags defines a list of custom tags with unique
+                      tag name.
+                    items:
+                      description: |-
+                        CustomTag defines custom tags with unique tag name
+                        to create tags for the active span.
+                      properties:
+                        literal:
+                          description: |-
+                            Literal is a static custom tag value.
+                            Precisely one of Literal, RequestHeaderName must be set.
+                          type: string
+                        requestHeaderName:
+                          description: |-
+                            RequestHeaderName indicates which request header
+                            the label value is obtained from.
+                            Precisely one of Literal, RequestHeaderName must be set.
+                          type: string
+                        tagName:
+                          description: TagName is the unique name of the custom tag.
+                          type: string
+                      required:
+                      - tagName
+                      type: object
+                    type: array
+                  extensionService:
+                    description: ExtensionService identifies the extension service
+                      defining the otel-collector.
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  includePodDetail:
+                    description: |-
+                      IncludePodDetail defines a flag.
+                      If it is true, contour will add the pod name and namespace to the span of the trace.
+                      the default is true.
+                      Note: The Envoy pods MUST have the HOSTNAME and CONTOUR_NAMESPACE environment variables set for this to work properly.
+                    type: boolean
+                  maxPathTagLength:
+                    description: |-
+                      MaxPathTagLength defines maximum length of the request path
+                      to extract and include in the HttpUrl tag.
+                      contour's default is 256.
+                    format: int32
+                    type: integer
+                  overallSampling:
+                    description: |-
+                      OverallSampling defines the sampling rate of trace data.
+                      contour's default is 100.
+                    type: string
+                  serviceName:
+                    description: |-
+                      ServiceName defines the name for the service.
+                      contour's default is contour.
+                    type: string
+                required:
+                - extensionService
+                type: object
+              xdsServer:
+                description: XDSServer contains parameters for the xDS server.
+                properties:
+                  address:
+                    description: |-
+                      Defines the xDS gRPC API address which Contour will serve.
+                      Contour's default is "0.0.0.0".
+                    minLength: 1
+                    type: string
+                  port:
+                    description: |-
+                      Defines the xDS gRPC API port which Contour will serve.
+                      Contour's default is 8001.
+                    type: integer
+                  tls:
+                    description: |-
+                      TLS holds TLS file config details.
+                      Contour's default is { caFile: "/certs/ca.crt", certFile: "/certs/tls.cert", keyFile: "/certs/tls.key", insecure: false }.
+                    properties:
+                      caFile:
+                        description: CA filename.
+                        type: string
+                      certFile:
+                        description: Client certificate filename.
+                        type: string
+                      insecure:
+                        description: Allow serving the xDS gRPC API without TLS.
+                        type: boolean
+                      keyFile:
+                        description: Client key filename.
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ContourConfigurationStatus defines the observed state of
+              a ContourConfiguration resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions contains the current status of the Contour resource.
+                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will not modify any other Conditions set in this block,
+                  in case some other controller wants to add a Condition.
+                items:
+                  description: |-
+                    DetailedCondition is an extension of the normal Kubernetes conditions, with two extra
+                    fields to hold sub-conditions, which provide more detailed reasons for the state (True or False)
+                    of the condition.
+                    `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
+                    `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
+                    Remember that Conditions have a type, a status, and a reason.
+                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
+                    In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
+                    `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
+                    slice in this case.
+                    `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
+                    The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`.
+                    For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
+                    When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
+                    In either case, there may be entries in the `warnings` slice.
+                    Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason
+                    (if there is one and only one entry in total across both the `errors` and `warnings` slices), or
+                    `MultipleReasons` if there is more than one entry.
+                  properties:
+                    errors:
+                      description: |-
+                        Errors contains a slice of relevant error subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: |-
+                        Warnings contains a slice of relevant warning subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant.
+                        An empty slice here indicates no warnings.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: contourdeployments.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ContourDeployment
+    listKind: ContourDeploymentList
+    plural: contourdeployments
+    shortNames:
+    - contourdeploy
+    singular: contourdeployment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContourDeployment is the schema for a Contour Deployment.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ContourDeploymentSpec specifies options for how a Contour
+              instance should be provisioned.
+            properties:
+              contour:
+                description: |-
+                  Contour specifies deployment-time settings for the Contour
+                  part of the installation, i.e. the xDS server/control plane
+                  and associated resources, including things like replica count
+                  for the Deployment, and node placement constraints for the pods.
+                properties:
+                  deployment:
+                    description: Deployment describes the settings for running contour
+                      as a `Deployment`.
+                    properties:
+                      replicas:
+                        description: Replicas is the desired number of replicas.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: Strategy describes the deployment strategy to
+                          use to replace existing pods with new pods.
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                    type: object
+                  disabledFeatures:
+                    description: |-
+                      DisabledFeatures defines an array of resources that will be ignored by
+                      contour reconciler.
+                    items:
+                      enum:
+                      - grpcroutes
+                      - tlsroutes
+                      - extensionservices
+                      - backendtlspolicies
+                      type: string
+                    maxItems: 42
+                    minItems: 1
+                    type: array
+                  kubernetesLogLevel:
+                    description: |-
+                      KubernetesLogLevel Enable Kubernetes client debug logging with log level. If unset,
+                      defaults to 0.
+                    maximum: 9
+                    minimum: 0
+                    type: integer
+                  logLevel:
+                    description: |-
+                      LogLevel sets the log level for Contour
+                      Allowed values are "info", "debug".
+                    type: string
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration
+                      of Contour pods.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is the simplest recommended form of node selection constraint
+                          and specifies a map of key-value pairs. For the pod to be eligible
+                          to run on a node, the node must have each of the indicated key-value pairs
+                          as labels (it can have additional labels as well).
+                          If unset, the pod(s) will be scheduled to any available node.
+                        type: object
+                      tolerations:
+                        description: |-
+                          Tolerations work with taints to ensure that pods are not scheduled
+                          onto inappropriate nodes. One or more taints are applied to a node; this
+                          marks that the node should not accept any pods that do not tolerate the
+                          taints.
+                          The default is an empty list.
+                          See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      PodAnnotations defines annotations to add to the Contour pods.
+                      the annotations for Prometheus will be appended or overwritten with predefined value.
+                    type: object
+                  replicas:
+                    description: |-
+                      Deprecated: Use `DeploymentSettings.Replicas` instead.
+                      Replicas is the desired number of Contour replicas. If if unset,
+                      defaults to 2.
+                      if both `DeploymentSettings.Replicas` and this one is set, use `DeploymentSettings.Replicas`.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: |-
+                      Compute Resources required by contour container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  watchNamespaces:
+                    description: |-
+                      WatchNamespaces is an array of namespaces. Setting it will instruct the contour instance
+                      to only watch this subset of namespaces.
+                    items:
+                      description: |-
+                        Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
+                        This validation is based off of the corresponding Kubernetes validation:
+                        https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L187
+                        This is used for Namespace name validation here:
+                        https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/api/validation/generic.go#L63
+                        Valid values include:
+                        * "example"
+                        Invalid values include:
+                        * "example.com" - "." is an invalid character
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    maxItems: 42
+                    minItems: 1
+                    type: array
+                type: object
+              envoy:
+                description: |-
+                  Envoy specifies deployment-time settings for the Envoy
+                  part of the installation, i.e. the xDS client/data plane
+                  and associated resources, including things like the workload
+                  type to use (DaemonSet or Deployment), node placement constraints
+                  for the pods, and various options for the Envoy service.
+                properties:
+                  baseID:
+                    description: |-
+                      The base ID to use when allocating shared memory regions.
+                      if Envoy needs to be run multiple times on the same machine, each running Envoy will need a unique base ID
+                      so that the shared memory regions do not conflict.
+                      defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  daemonSet:
+                    description: |-
+                      DaemonSet describes the settings for running envoy as a `DaemonSet`.
+                      if `WorkloadType` is `Deployment`,it's must be nil
+                    properties:
+                      updateStrategy:
+                        description: Strategy describes the deployment strategy to
+                          use to replace existing DaemonSet pods with new pods.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only
+                              if type = "RollingUpdate".
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of nodes with an existing available DaemonSet pod that
+                                  can have an updated DaemonSet pod during during an update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                                  Default value is 0.
+                                  Example: when this is set to 30%, at most 30% of the total number of nodes
+                                  that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                  can have their a new pod created before the old pod is marked as deleted.
+                                  The update starts by launching new pods on 30% of nodes. Once an updated
+                                  pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                                  on that node is marked deleted. If the old pod becomes unavailable for any
+                                  reason (Ready transitions to false, is evicted, or is drained) an updated
+                                  pod is immediatedly created on that node without considering surge limits.
+                                  Allowing surge implies the possibility that the resources consumed by the
+                                  daemonset on any given node can double if the readiness check fails, and
+                                  so resource intensive daemonsets should take into account that they may
+                                  cause evictions during disruption.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of DaemonSet pods that can be unavailable during the
+                                  update. Value can be an absolute number (ex: 5) or a percentage of total
+                                  number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                                  number is calculated from percentage by rounding up.
+                                  This cannot be 0 if MaxSurge is 0
+                                  Default value is 1.
+                                  Example: when this is set to 30%, at most 30% of the total number of nodes
+                                  that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                  can have their pods stopped for an update at any given time. The update
+                                  starts by stopping at most 30% of those DaemonSet pods and then brings
+                                  up new DaemonSet pods in their place. Once the new pods are available,
+                                  it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                                  70% of original number of DaemonSet pods are available at all times during
+                                  the update.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of daemon set update. Can be "RollingUpdate"
+                              or "OnDelete". Default is RollingUpdate.
+                            type: string
+                        type: object
+                    type: object
+                  deployment:
+                    description: |-
+                      Deployment describes the settings for running envoy as a `Deployment`.
+                      if `WorkloadType` is `DaemonSet`,it's must be nil
+                    properties:
+                      replicas:
+                        description: Replicas is the desired number of replicas.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: Strategy describes the deployment strategy to
+                          use to replace existing pods with new pods.
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                    type: object
+                  extraVolumeMounts:
+                    description: ExtraVolumeMounts holds the extra volume mounts to
+                      add (normally used with extraVolumes).
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  extraVolumes:
+                    description: ExtraVolumes holds the extra volumes to add.
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: boolean
+                            volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: |-
+                            azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                            are redirected to the disk.csi.azure.com CSI driver.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              default: ext4
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              default: false
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: |-
+                            azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                            are redirected to the file.csi.azure.com CSI driver.
+                          properties:
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: |-
+                            cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                          properties:
+                            monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: boolean
+                            secretFile:
+                              description: |-
+                                secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                            are redirected to the cinder.csi.openstack.org CSI driver.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers.
+                          properties:
+                            driver:
+                              description: |-
+                                driver is the name of the CSI driver that handles this volume.
+                                Consult with your admin for the correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the associated CSI driver
+                                which will determine the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to complete the CSI
+                                NodePublishVolume and NodeUnpublishVolume calls.
+                                This field is optional, and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret references are passed.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver. Consult your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                Optional: mode bits to use on created files by default. Must be a
+                                Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          properties:
+                            medium:
+                              description: |-
+                                medium represents what type of storage medium should back this directory.
+                                The default is "" which means to use the node's default medium.
+                                Must be an empty string (default) or Memory.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                The size limit is also applicable for memory medium.
+                                The maximum usage on memory medium EmptyDir would be the minimum value between
+                                the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                The default is nil which means that the limit is undefined.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver.
+                            The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                            and deleted when the pod is removed.
+                            Use this if:
+                            a) the volume is only needed while the pod runs,
+                            b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and
+                            d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+                            Use PersistentVolumeClaim or one of the vendor-specific
+                            APIs for volumes that persist for longer than the lifecycle
+                            of an individual pod.
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                            be used that way - see the documentation of the driver for
+                            more information.
+                            A pod can use both types of ephemeral volumes and
+                            persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume.
+                                The pod in which this EphemeralVolumeSource is embedded will be the
+                                owner of the PVC, i.e. the PVC will be deleted together with the
+                                pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes` array
+                                entry. Pod validation will reject the pod if the concatenated name
+                                is not valid for a PVC (for example, too long).
+                                An existing PVC with that name that is not owned by the pod
+                                will *not* be used for the pod to avoid using an unrelated
+                                volume by mistake. Starting the pod is then blocked until
+                                the unrelated PVC is removed. If such a pre-created PVC is
+                                meant to be used by the pod, the PVC has to updated with an
+                                owner reference to the pod once the pod exists. Normally
+                                this should not be necessary, but it may be useful when
+                                manually reconstructing a broken cluster.
+                                This field is read-only and no changes will be made by Kubernetes
+                                to the PVC after it has been created.
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it. No other fields are allowed and will be rejected during
+                                    validation.
+                                  type: object
+                                spec:
+                                  description: |-
+                                    The specification for the PersistentVolumeClaim. The entire content is
+                                    copied unchanged into the PVC that gets created from this
+                                    template. The same fields as in a PersistentVolumeClaim
+                                    are also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller can support the specified data source,
+                                        it will create a new volume based on the contents of the specified data source.
+                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding will only succeed if the type of
+                                        the specified object matches some installed volume populator or dynamic
+                                        provisioner.
+                                        This field will replace the functionality of the dataSource field and as such
+                                        if both fields are non-empty, they must have the same value. For backwards
+                                        compatibility, when namespace isn't specified in dataSourceRef,
+                                        both fields (dataSource and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty and the other is non-empty.
+                                        When namespace is specified in dataSourceRef,
+                                        dataSource isn't set to the same value and must be empty.
+                                        There are three important differences between dataSource and dataSourceRef:
+                                        * While dataSource only allows two specific types of objects, dataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        * While dataSource only allows local objects, dataSourceRef allows objects
+                                          in any namespaces.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                            (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: |-
+                                        resources represents the minimum resources the volume should have.
+                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        that are lower than previous value but must still be higher than capacity recorded in the
+                                        status field of the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: |-
+                                        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                        If specified, the CSI driver will create or update the volume with the attributes defined
+                                        in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller if it exists.
+                                        If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                        set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                        exists.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                      type: string
+                                    volumeMode:
+                                      description: |-
+                                        volumeMode defines what type of volume is required by the claim.
+                                        Value of Filesystem is implied when not included in claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            wwids:
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
+                            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugin scripts. This may be
+                                empty if no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed to the plugin
+                                scripts.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: |-
+                            flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                          properties:
+                            datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                            EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                            into the Pod's container.
+                          properties:
+                            directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                          properties:
+                            endpoints:
+                              description: |-
+                                endpoints is the endpoint name that details Glusterfs topology.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container. This is generally
+                            used for system agents or other privileged things that are allowed
+                            to see the host machine. Most containers will NOT need this.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          properties:
+                            path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                            type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        image:
+                          description: |-
+                            image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                            The volume is resolved at pod startup depending on which PullPolicy value is provided:
+                            - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                            A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                            The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                            The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                            The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                                Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                          type: object
+                        iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              type: string
+                            initiatorName:
+                              description: |-
+                                initiatorName is the custom iSCSI Initiator Name.
+                                If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                <target portal>:<volume name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              default: default
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: |-
+                                portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            targetPortal:
+                              description: |-
+                                targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          properties:
+                            path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: boolean
+                            server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: |-
+                            photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: |-
+                            portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                            Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                            is on.
+                          properties:
+                            fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode are the mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
+                              items:
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
+                                properties:
+                                  clusterTrustBundle:
+                                    description: |-
+                                      ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                      of ClusterTrustBundle objects in an auto-updating file.
+                                      Alpha, gated by the ClusterTrustBundleProjection feature gate.
+                                      ClusterTrustBundle objects can either be selected by name, or by the
+                                      combination of signer name and a label selector.
+                                      Kubelet performs aggressive normalization of the PEM contents written
+                                      into the pod filesystem.  Esoteric PEM features such as inter-block
+                                      comments and block headers are stripped.  Certificates are deduplicated.
+                                      The ordering of certificates within the file is arbitrary, and Kubelet
+                                      may change the order over time.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                          interpreted as "match nothing".  If set but empty, interpreted as "match
+                                          everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the named ClusterTrustBundle is
+                                          allowed not to exist.  If using signerName, then the combination of
+                                          signerName and labelSelector is allowed to match zero
+                                          ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: |-
+                                          audience is the intended audience of the token. A recipient of a token
+                                          must identify itself with an identifier specified in the audience of the
+                                          token, and otherwise should reject the token. The audience defaults to the
+                                          identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token. As the token approaches expiration, the kubelet volume
+                                          plugin will proactively rotate the service account token. The kubelet will
+                                          start trying to rotate the token if the token is older than 80 percent of
+                                          its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                          and must be at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        quobyte:
+                          description: |-
+                            quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                          properties:
+                            group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
+                              type: boolean
+                            registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple entries are separated with commas)
+                                which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              type: string
+                            image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            keyring:
+                              default: /etc/ceph/keyring
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            pool:
+                              default: rbd
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              default: admin
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          description: |-
+                            scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                          properties:
+                            fsType:
+                              default: xfs
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs".
+                                Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information. If this is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              default: ThinProvisioned
+                              description: |-
+                                storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values
+                                for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              type: string
+                          type: object
+                        storageos:
+                          description: |-
+                            storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.  If not specified, default values will be attempted.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: |-
+                                volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                namespace is specified then the Pod's namespace will be used.  This allows the
+                                Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                Set VolumeName to any name to override the default behaviour.
+                                Set to "default" if you are not using namespaces within StorageOS.
+                                Namespaces that do not pre-exist within StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: |-
+                            vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                            Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                            are redirected to the csi.vsphere.vmware.com CSI driver.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  logLevel:
+                    description: |-
+                      LogLevel sets the log level for Envoy.
+                      Allowed values are "trace", "debug", "info", "warn", "error", "critical", "off".
+                    type: string
+                  networkPublishing:
+                    description: NetworkPublishing defines how to expose Envoy to
+                      a network.
+                    properties:
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,
+                          and LoadBalancer IPs).
+                          If unset, defaults to "Local".
+                        type: string
+                      ipFamilyPolicy:
+                        description: |-
+                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                          this Service. If there is no value provided, then this field will be set
+                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                          a single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise fail).
+                        type: string
+                      serviceAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAnnotations is the annotations to add to
+                          the provisioned Envoy service.
+                        type: object
+                      type:
+                        description: |-
+                          NetworkPublishingType is the type of publishing strategy to use. Valid values are:
+                          * LoadBalancerService
+                          In this configuration, network endpoints for Envoy use container networking.
+                          A Kubernetes LoadBalancer Service is created to publish Envoy network
+                          endpoints.
+                          See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          * NodePortService
+                          Publishes Envoy network endpoints using a Kubernetes NodePort Service.
+                          In this configuration, Envoy network endpoints use container networking. A Kubernetes
+                          NodePort Service is created to publish the network endpoints.
+                          See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          NOTE:
+                          When provisioning an Envoy `NodePortService`, use Gateway Listeners' port numbers to populate
+                          the Service's node port values, there's no way to auto-allocate them.
+                          See: https://github.com/projectcontour/contour/issues/4499
+                          * ClusterIPService
+                          Publishes Envoy network endpoints using a Kubernetes ClusterIP Service.
+                          In this configuration, Envoy network endpoints use container networking. A Kubernetes
+                          ClusterIP Service is created to publish the network endpoints.
+                          See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          If unset, defaults to LoadBalancerService.
+                        type: string
+                    type: object
+                  nodePlacement:
+                    description: NodePlacement describes node scheduling configuration
+                      of Envoy pods.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is the simplest recommended form of node selection constraint
+                          and specifies a map of key-value pairs. For the pod to be eligible
+                          to run on a node, the node must have each of the indicated key-value pairs
+                          as labels (it can have additional labels as well).
+                          If unset, the pod(s) will be scheduled to any available node.
+                        type: object
+                      tolerations:
+                        description: |-
+                          Tolerations work with taints to ensure that pods are not scheduled
+                          onto inappropriate nodes. One or more taints are applied to a node; this
+                          marks that the node should not accept any pods that do not tolerate the
+                          taints.
+                          The default is an empty list.
+                          See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  overloadMaxDownstreamConnections:
+                    description: |-
+                      OverloadMaxDownstreamConn defines the envoy global downstream connection limit controlled by the overload manager.
+                      When the value is greater than 0 the overload manager is enabled and listeners
+                      will begin rejecting connections when the the connection threshold is hit.
+                      Metrics and health listeners are not subject to the connection limits, however,
+                      they still count against the global limit.
+                    format: int64
+                    type: integer
+                  overloadMaxHeapSize:
+                    description: |-
+                      OverloadMaxHeapSize defines the maximum heap memory of the envoy controlled by the overload manager.
+                      When the value is greater than 0, the overload manager is enabled,
+                      and when envoy reaches 95% of the maximum heap size, it performs a shrink heap operation,
+                      When it reaches 98% of the maximum heap size, Envoy Will stop accepting requests.
+                      More info: https://projectcontour.io/docs/main/config/overload-manager/
+                    format: int64
+                    type: integer
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      PodAnnotations defines annotations to add to the Envoy pods.
+                      the annotations for Prometheus will be appended or overwritten with predefined value.
+                    type: object
+                  replicas:
+                    description: |-
+                      Deprecated: Use `DeploymentSettings.Replicas` instead.
+                      Replicas is the desired number of Envoy replicas. If WorkloadType
+                      is not "Deployment", this field is ignored. Otherwise, if unset,
+                      defaults to 2.
+                      if both `DeploymentSettings.Replicas` and this one is set, use `DeploymentSettings.Replicas`.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: |-
+                      Compute Resources required by envoy container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  workloadType:
+                    description: |-
+                      WorkloadType is the type of workload to install Envoy
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
+                    type: string
+                type: object
+              resourceLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ResourceLabels is a set of labels to add to the provisioned Contour resources.
+                  Deprecated: use Gateway.Spec.Infrastructure.Labels instead. This field will be
+                  removed in a future release.
+                type: object
+              runtimeSettings:
+                description: |-
+                  RuntimeSettings is a ContourConfiguration spec to be used when
+                  provisioning a Contour instance that will influence aspects of
+                  the Contour instance's runtime behavior.
+                properties:
+                  debug:
+                    description: |-
+                      Debug contains parameters to enable debug logging
+                      and debug interfaces inside Contour.
+                    properties:
+                      address:
+                        description: |-
+                          Defines the Contour debug address interface.
+                          Contour's default is "127.0.0.1".
+                        type: string
+                      port:
+                        description: |-
+                          Defines the Contour debug address port.
+                          Contour's default is 6060.
+                        type: integer
+                    type: object
+                  enableExternalNameService:
+                    description: |-
+                      EnableExternalNameService allows processing of ExternalNameServices
+                      Contour's default is false for security reasons.
+                    type: boolean
+                  envoy:
+                    description: |-
+                      Envoy contains parameters for Envoy as well
+                      as how to optionally configure a managed Envoy fleet.
+                    properties:
+                      clientCertificate:
+                        description: |-
+                          ClientCertificate defines the namespace/name of the Kubernetes
+                          secret containing the client certificate and private key
+                          to be used when establishing TLS connection to upstream
+                          cluster.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      cluster:
+                        description: |-
+                          Cluster holds various configurable Envoy cluster values that can
+                          be set in the config file.
+                        properties:
+                          circuitBreakers:
+                            description: |-
+                              GlobalCircuitBreakerDefaults specifies default circuit breaker budget across all services.
+                              If defined, this will be used as the default for all services.
+                            properties:
+                              maxConnections:
+                                description: The maximum number of connections that
+                                  a single Envoy instance allows to the Kubernetes
+                                  Service; defaults to 1024.
+                                format: int32
+                                type: integer
+                              maxPendingRequests:
+                                description: The maximum number of pending requests
+                                  that a single Envoy instance allows to the Kubernetes
+                                  Service; defaults to 1024.
+                                format: int32
+                                type: integer
+                              maxRequests:
+                                description: The maximum parallel requests a single
+                                  Envoy instance allows to the Kubernetes Service;
+                                  defaults to 1024
+                                format: int32
+                                type: integer
+                              maxRetries:
+                                description: The maximum number of parallel retries
+                                  a single Envoy instance allows to the Kubernetes
+                                  Service; defaults to 3.
+                                format: int32
+                                type: integer
+                              perHostMaxConnections:
+                                description: |-
+                                  PerHostMaxConnections is the maximum number of connections
+                                  that Envoy will allow to each individual host in a cluster.
+                                format: int32
+                                type: integer
+                            type: object
+                          dnsLookupFamily:
+                            description: |-
+                              DNSLookupFamily defines how external names are looked up
+                              When configured as V4, the DNS resolver will only perform a lookup
+                              for addresses in the IPv4 family. If V6 is configured, the DNS resolver
+                              will only perform a lookup for addresses in the IPv6 family.
+                              If AUTO is configured, the DNS resolver will first perform a lookup
+                              for addresses in the IPv6 family and fallback to a lookup for addresses
+                              in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+                              both IPv4 and IPv6 families, and return all resolved addresses.
+                              When this is used, Happy Eyeballs will be enabled for upstream connections.
+                              Refer to Happy Eyeballs Support for more information.
+                              Note: This only applies to externalName clusters.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information.
+                              Values: `auto` (default), `v4`, `v6`, `all`.
+                              Other values will produce an error.
+                            type: string
+                          maxRequestsPerConnection:
+                            description: |-
+                              Defines the maximum requests for upstream connections. If not specified, there is no limit.
+                              see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                              for more information.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          per-connection-buffer-limit-bytes:
+                            description: |-
+                              Defines the soft limit on size of the cluster’s new connection read and write buffers in bytes.
+                              If unspecified, an implementation defined default is applied (1MiB).
+                              see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-per-connection-buffer-limit-bytes
+                              for more information.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          upstreamTLS:
+                            description: UpstreamTLS contains the TLS policy parameters
+                              for upstream connections
+                            properties:
+                              cipherSuites:
+                                description: |-
+                                  CipherSuites defines the TLS ciphers to be supported by Envoy TLS
+                                  listeners when negotiating TLS 1.2. Ciphers are validated against the
+                                  set that Envoy supports by default. This parameter should only be used
+                                  by advanced users. Note that these will be ignored when TLS 1.3 is in
+                                  use.
+                                  This field is optional; when it is undefined, a Contour-managed ciphersuite list
+                                  will be used, which may be updated to keep it secure.
+                                  Contour's default list is:
+                                    - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                    - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                    - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                    - "ECDHE-RSA-AES256-GCM-SHA384"
+                                  Ciphers provided are validated against the following list:
+                                    - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                    - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                    - "ECDHE-ECDSA-AES128-GCM-SHA256"
+                                    - "ECDHE-RSA-AES128-GCM-SHA256"
+                                    - "ECDHE-ECDSA-AES128-SHA"
+                                    - "ECDHE-RSA-AES128-SHA"
+                                    - "AES128-GCM-SHA256"
+                                    - "AES128-SHA"
+                                    - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                    - "ECDHE-RSA-AES256-GCM-SHA384"
+                                    - "ECDHE-ECDSA-AES256-SHA"
+                                    - "ECDHE-RSA-AES256-SHA"
+                                    - "AES256-GCM-SHA384"
+                                    - "AES256-SHA"
+                                  Contour recommends leaving this undefined unless you are sure you must.
+                                  See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                                  Note: This list is a superset of what is valid for stock Envoy builds and those using BoringSSL FIPS.
+                                items:
+                                  type: string
+                                type: array
+                              maximumProtocolVersion:
+                                description: |-
+                                  MaximumProtocolVersion is the maximum TLS version this vhost should
+                                  negotiate.
+                                  Values: `1.2`, `1.3`(default).
+                                  Other values will produce an error.
+                                type: string
+                              minimumProtocolVersion:
+                                description: |-
+                                  MinimumProtocolVersion is the minimum TLS version this vhost should
+                                  negotiate.
+                                  Values: `1.2` (default), `1.3`.
+                                  Other values will produce an error.
+                                type: string
+                            type: object
+                        type: object
+                      defaultHTTPVersions:
+                        description: |-
+                          DefaultHTTPVersions defines the default set of HTTPS
+                          versions the proxy should accept. HTTP versions are
+                          strings of the form "HTTP/xx". Supported versions are
+                          "HTTP/1.1" and "HTTP/2".
+                          Values: `HTTP/1.1`, `HTTP/2` (default: both).
+                          Other values will produce an error.
+                        items:
+                          description: HTTPVersionType is the name of a supported
+                            HTTP version.
+                          type: string
+                        type: array
+                      health:
+                        description: |-
+                          Health defines the endpoint Envoy uses to serve health checks.
+                          Contour's default is { address: "0.0.0.0", port: 8002 }.
+                        properties:
+                          address:
+                            description: Defines the health address interface.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines the health port.
+                            type: integer
+                        type: object
+                      http:
+                        description: |-
+                          Defines the HTTP Listener for Envoy.
+                          Contour's default is { address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout" }.
+                        properties:
+                          accessLog:
+                            description: AccessLog defines where Envoy logs are outputted
+                              for this listener.
+                            type: string
+                          address:
+                            description: Defines an Envoy Listener Address.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines an Envoy listener Port.
+                            type: integer
+                        type: object
+                      https:
+                        description: |-
+                          Defines the HTTPS Listener for Envoy.
+                          Contour's default is { address: "0.0.0.0", port: 8443, accessLog: "/dev/stdout" }.
+                        properties:
+                          accessLog:
+                            description: AccessLog defines where Envoy logs are outputted
+                              for this listener.
+                            type: string
+                          address:
+                            description: Defines an Envoy Listener Address.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines an Envoy listener Port.
+                            type: integer
+                        type: object
+                      listener:
+                        description: Listener hold various configurable Envoy listener
+                          values.
+                        properties:
+                          compression:
+                            description: Compression defines configuration related
+                              to compression in the default HTTP Listener filters.
+                            properties:
+                              algorithm:
+                                description: |-
+                                  Algorithm selects the response compression type applied in the compression HTTP filter of the default Listener filters.
+                                  Values: `gzip` (default), `brotli`, `zstd`, `disabled`.
+                                  Setting this to `disabled` will make Envoy skip "Accept-Encoding: gzip,deflate" request header and always return uncompressed response.
+                                enum:
+                                - gzip
+                                - brotli
+                                - zstd
+                                - disabled
+                                type: string
+                            type: object
+                          connectionBalancer:
+                            description: |-
+                              ConnectionBalancer. If the value is exact, the listener will use the exact connection balancer
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                              for more information.
+                              Values: (empty string): use the default ConnectionBalancer, `exact`: use the Exact ConnectionBalancer.
+                              Other values will produce an error.
+                            type: string
+                          disableAllowChunkedLength:
+                            description: |-
+                              DisableAllowChunkedLength disables the RFC-compliant Envoy behavior to
+                              strip the "Content-Length" header if "Transfer-Encoding: chunked" is
+                              also set. This is an emergency off-switch to revert back to Envoy's
+                              default behavior in case of failures. Please file an issue if failures
+                              are encountered.
+                              See: https://github.com/projectcontour/contour/issues/3221
+                              Contour's default is false.
+                            type: boolean
+                          disableMergeSlashes:
+                            description: |-
+                              DisableMergeSlashes disables Envoy's non-standard merge_slashes path transformation option
+                              which strips duplicate slashes from request URL paths.
+                              Contour's default is false.
+                            type: boolean
+                          httpMaxConcurrentStreams:
+                            description: |-
+                              Defines the value for SETTINGS_MAX_CONCURRENT_STREAMS Envoy will advertise in the
+                              SETTINGS frame in HTTP/2 connections and the limit for concurrent streams allowed
+                              for a peer on a single HTTP/2 connection. It is recommended to not set this lower
+                              than 100 but this field can be used to bound resource usage by HTTP/2 connections
+                              and mitigate attacks like CVE-2023-44487. The default value when this is not set is
+                              unlimited.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          maxConnectionsPerListener:
+                            description: |-
+                              Defines the limit on number of active connections to a listener. The limit is applied
+                              per listener. The default value when this is not set is unlimited.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          maxRequestsPerConnection:
+                            description: |-
+                              Defines the maximum requests for downstream connections. If not specified, there is no limit.
+                              see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-msg-config-core-v3-httpprotocoloptions
+                              for more information.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          maxRequestsPerIOCycle:
+                            description: |-
+                              Defines the limit on number of HTTP requests that Envoy will process from a single
+                              connection in a single I/O cycle. Requests over this limit are processed in subsequent
+                              I/O cycles. Can be used as a mitigation for CVE-2023-44487 when abusive traffic is
+                              detected. Configures the http.max_requests_per_io_cycle Envoy runtime setting. The default
+                              value when this is not set is no limit.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          per-connection-buffer-limit-bytes:
+                            description: |-
+                              Defines the soft limit on size of the listener’s new connection read and write buffers in bytes.
+                              If unspecified, an implementation defined default is applied (1MiB).
+                              see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-per-connection-buffer-limit-bytes
+                              for more information.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          serverHeaderTransformation:
+                            description: |-
+                              Defines the action to be applied to the Server header on the response path.
+                              When configured as overwrite, overwrites any Server header with "envoy".
+                              When configured as append_if_absent, if a Server header is present, pass it through, otherwise set it to "envoy".
+                              When configured as pass_through, pass through the value of the Server header, and do not append a header if none is present.
+                              Values: `overwrite` (default), `append_if_absent`, `pass_through`
+                              Other values will produce an error.
+                              Contour's default is overwrite.
+                            type: string
+                          socketOptions:
+                            description: |-
+                              SocketOptions defines configurable socket options for the listeners.
+                              Single set of options are applied to all listeners.
+                            properties:
+                              tos:
+                                description: |-
+                                  Defines the value for IPv4 TOS field (including 6 bit DSCP field) for IP packets originating from Envoy listeners.
+                                  Single value is applied to all listeners.
+                                  If listeners are bound to IPv6-only addresses, setting this option will cause an error.
+                                format: int32
+                                maximum: 255
+                                minimum: 0
+                                type: integer
+                              trafficClass:
+                                description: |-
+                                  Defines the value for IPv6 Traffic Class field (including 6 bit DSCP field) for IP packets originating from the Envoy listeners.
+                                  Single value is applied to all listeners.
+                                  If listeners are bound to IPv4-only addresses, setting this option will cause an error.
+                                format: int32
+                                maximum: 255
+                                minimum: 0
+                                type: integer
+                            type: object
+                          tls:
+                            description: TLS holds various configurable Envoy TLS
+                              listener values.
+                            properties:
+                              cipherSuites:
+                                description: |-
+                                  CipherSuites defines the TLS ciphers to be supported by Envoy TLS
+                                  listeners when negotiating TLS 1.2. Ciphers are validated against the
+                                  set that Envoy supports by default. This parameter should only be used
+                                  by advanced users. Note that these will be ignored when TLS 1.3 is in
+                                  use.
+                                  This field is optional; when it is undefined, a Contour-managed ciphersuite list
+                                  will be used, which may be updated to keep it secure.
+                                  Contour's default list is:
+                                    - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                    - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                    - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                    - "ECDHE-RSA-AES256-GCM-SHA384"
+                                  Ciphers provided are validated against the following list:
+                                    - "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+                                    - "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+                                    - "ECDHE-ECDSA-AES128-GCM-SHA256"
+                                    - "ECDHE-RSA-AES128-GCM-SHA256"
+                                    - "ECDHE-ECDSA-AES128-SHA"
+                                    - "ECDHE-RSA-AES128-SHA"
+                                    - "AES128-GCM-SHA256"
+                                    - "AES128-SHA"
+                                    - "ECDHE-ECDSA-AES256-GCM-SHA384"
+                                    - "ECDHE-RSA-AES256-GCM-SHA384"
+                                    - "ECDHE-ECDSA-AES256-SHA"
+                                    - "ECDHE-RSA-AES256-SHA"
+                                    - "AES256-GCM-SHA384"
+                                    - "AES256-SHA"
+                                  Contour recommends leaving this undefined unless you are sure you must.
+                                  See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                                  Note: This list is a superset of what is valid for stock Envoy builds and those using BoringSSL FIPS.
+                                items:
+                                  type: string
+                                type: array
+                              maximumProtocolVersion:
+                                description: |-
+                                  MaximumProtocolVersion is the maximum TLS version this vhost should
+                                  negotiate.
+                                  Values: `1.2`, `1.3`(default).
+                                  Other values will produce an error.
+                                type: string
+                              minimumProtocolVersion:
+                                description: |-
+                                  MinimumProtocolVersion is the minimum TLS version this vhost should
+                                  negotiate.
+                                  Values: `1.2` (default), `1.3`.
+                                  Other values will produce an error.
+                                type: string
+                            type: object
+                          useProxyProtocol:
+                            description: |-
+                              Use PROXY protocol for all listeners.
+                              Contour's default is false.
+                            type: boolean
+                        type: object
+                      logging:
+                        description: Logging defines how Envoy's logs can be configured.
+                        properties:
+                          accessLogFormat:
+                            description: |-
+                              AccessLogFormat sets the global access log format.
+                              Values: `envoy` (default), `json`.
+                              Other values will produce an error.
+                            type: string
+                          accessLogFormatString:
+                            description: |-
+                              AccessLogFormatString sets the access log format when format is set to `envoy`.
+                              When empty, Envoy's default format is used.
+                            type: string
+                          accessLogJSONFields:
+                            description: |-
+                              AccessLogJSONFields sets the fields that JSON logging will
+                              output when AccessLogFormat is json.
+                            items:
+                              type: string
+                            type: array
+                          accessLogLevel:
+                            description: |-
+                              AccessLogLevel sets the verbosity level of the access log.
+                              Values: `info` (default, all requests are logged), `error` (all non-success requests, i.e. 300+ response code, are logged), `critical` (all 5xx requests are logged) and `disabled`.
+                              Other values will produce an error.
+                            type: string
+                        type: object
+                      metrics:
+                        description: |-
+                          Metrics defines the endpoint Envoy uses to serve metrics.
+                          Contour's default is { address: "0.0.0.0", port: 8002 }.
+                        properties:
+                          address:
+                            description: Defines the metrics address interface.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines the metrics port.
+                            type: integer
+                          tls:
+                            description: |-
+                              TLS holds TLS file config details.
+                              Metrics and health endpoints cannot have same port number when metrics is served over HTTPS.
+                            properties:
+                              caFile:
+                                description: CA filename.
+                                type: string
+                              certFile:
+                                description: Client certificate filename.
+                                type: string
+                              keyFile:
+                                description: Client key filename.
+                                type: string
+                            type: object
+                        type: object
+                      network:
+                        description: Network holds various configurable Envoy network
+                          values.
+                        properties:
+                          adminPort:
+                            description: |-
+                              Configure the port used to access the Envoy Admin interface.
+                              If configured to port "0" then the admin interface is disabled.
+                              Contour's default is 9001.
+                            type: integer
+                          numTrustedHops:
+                            description: |-
+                              XffNumTrustedHops defines the number of additional ingress proxy hops from the
+                              right side of the x-forwarded-for HTTP header to trust when determining the origin
+                              client’s IP address.
+                              See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                              for more information.
+                              Contour's default is 0.
+                            format: int32
+                            type: integer
+                          stripTrailingHostDot:
+                            description: |-
+                              EnvoyStripTrailingHostDot defines if trailing dot of the host should be removed from host/authority header
+                              before any processing of request by HTTP filters or routing. This
+                              affects the upstream host header. Without setting this option to true, incoming
+                              requests with host example.com. will not match against route with domains
+                              match set to example.com.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=strip_trailing_host_dot
+                              for more information.
+                              Contour's default is false.
+                            type: boolean
+                        type: object
+                      omEnforcedHealth:
+                        description: |-
+                          OMEnforcedHealth defines the endpoint Envoy uses to serve health checks with
+                          the envoy overload manager actions, such as global connection limits, enforced.
+                          The configured values must be different from the endpoints
+                          configured by [EnvoyConfig.Metrics] and [EnvoyConfig.Health]
+                          This is disabled by default
+                        properties:
+                          address:
+                            description: Defines the health address interface.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines the health port.
+                            type: integer
+                        type: object
+                      service:
+                        description: |-
+                          Service holds Envoy service parameters for setting Ingress status.
+                          Contour's default is { namespace: "projectcontour", name: "envoy" }.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      timeouts:
+                        description: |-
+                          Timeouts holds various configurable timeouts that can
+                          be set in the config file.
+                        properties:
+                          connectTimeout:
+                            description: |-
+                              ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
+                              If not set, a default value of 2 seconds will be used.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                              for more information.
+                            type: string
+                          connectionIdleTimeout:
+                            description: |-
+                              ConnectionIdleTimeout defines how long the proxy should wait while there are
+                              no active requests (for HTTP/1.1) or streams (for HTTP/2) before terminating
+                              an HTTP connection. Set to "infinity" to disable the timeout entirely.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+                              for more information.
+                            type: string
+                          connectionShutdownGracePeriod:
+                            description: |-
+                              ConnectionShutdownGracePeriod defines how long the proxy will wait between sending an
+                              initial GOAWAY frame and a second, final GOAWAY frame when terminating an HTTP/2 connection.
+                              During this grace period, the proxy will continue to respond to new streams. After the final
+                              GOAWAY frame has been sent, the proxy will refuse new streams.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+                              for more information.
+                            type: string
+                          delayedCloseTimeout:
+                            description: |-
+                              DelayedCloseTimeout defines how long envoy will wait, once connection
+                              close processing has been initiated, for the downstream peer to close
+                              the connection before Envoy closes the socket associated with the connection.
+                              Setting this timeout to 'infinity' will disable it, equivalent to setting it to '0'
+                              in Envoy. Leaving it unset will result in the Envoy default value being used.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
+                              for more information.
+                            type: string
+                          maxConnectionDuration:
+                            description: |-
+                              MaxConnectionDuration defines the maximum period of time after an HTTP connection
+                              has been established from the client to the proxy before it is closed by the proxy,
+                              regardless of whether there has been activity or not. Omit or set to "infinity" for
+                              no max duration.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+                              for more information.
+                            type: string
+                          requestTimeout:
+                            description: |-
+                              RequestTimeout sets the client request timeout globally for Contour. Note that
+                              this is a timeout for the entire request, not an idle timeout. Omit or set to
+                              "infinity" to disable the timeout entirely.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
+                              for more information.
+                            type: string
+                          streamIdleTimeout:
+                            description: |-
+                              StreamIdleTimeout defines how long the proxy should wait while there is no
+                              request activity (for HTTP/1.1) or stream activity (for HTTP/2) before
+                              terminating the HTTP request or stream. Set to "infinity" to disable the
+                              timeout entirely.
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+                              for more information.
+                            type: string
+                        type: object
+                    type: object
+                  featureFlags:
+                    description: FeatureFlags defines toggle to enable new contour
+                      features.
+                    items:
+                      type: string
+                    type: array
+                  gateway:
+                    description: |-
+                      Gateway contains parameters for the gateway-api Gateway that Contour
+                      is configured to serve traffic.
+                    properties:
+                      gatewayRef:
+                        description: |-
+                          GatewayRef defines the specific Gateway that this Contour
+                          instance corresponds to.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - gatewayRef
+                    type: object
+                  globalExtAuth:
+                    description: |-
+                      GlobalExternalAuthorization allows envoys external authorization filter
+                      to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: |-
+                          AuthPolicy sets a default authorization policy for client requests.
+                          This policy will be used unless overridden by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Context is a set of key/value pairs that are sent to the
+                              authentication server in the check request. If a context
+                              is provided at an enclosing scope, the entries are merged
+                              such that the inner scope overrides matching keys from the
+                              outer scope.
+                            type: object
+                          disabled:
+                            description: |-
+                              When true, this field disables client request authentication
+                              for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: |-
+                              API version of the referent.
+                              If this field is not specified, the default "projectcontour.io/v1alpha1" will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              If this field is not specifies, the namespace of the resource that targets the referent will be used.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: |-
+                          If FailOpen is true, the client request is forwarded to the upstream service
+                          even if the authorization server fails to respond. This field should not be
+                          set in most cases. It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: |-
+                          ResponseTimeout configures maximum time to wait for a check response from the authorization server.
+                          Timeout durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                          The string "infinity" is also a valid input and specifies no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
+                  health:
+                    description: |-
+                      Health defines the endpoints Contour uses to serve health checks.
+                      Contour's default is { address: "0.0.0.0", port: 8000 }.
+                    properties:
+                      address:
+                        description: Defines the health address interface.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the health port.
+                        type: integer
+                    type: object
+                  httpproxy:
+                    description: HTTPProxy defines parameters on HTTPProxy.
+                    properties:
+                      disablePermitInsecure:
+                        description: |-
+                          DisablePermitInsecure disables the use of the
+                          permitInsecure field in HTTPProxy.
+                          Contour's default is false.
+                        type: boolean
+                      fallbackCertificate:
+                        description: |-
+                          FallbackCertificate defines the namespace/name of the Kubernetes secret to
+                          use as fallback when a non-SNI request is received.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      rootNamespaces:
+                        description: Restrict Contour to searching these namespaces
+                          for root ingress routes.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  ingress:
+                    description: Ingress contains parameters for ingress options.
+                    properties:
+                      classNames:
+                        description: Ingress Class Names Contour should use.
+                        items:
+                          type: string
+                        type: array
+                      statusAddress:
+                        description: Address to set in Ingress object status.
+                        type: string
+                    type: object
+                  metrics:
+                    description: |-
+                      Metrics defines the endpoint Contour uses to serve metrics.
+                      Contour's default is { address: "0.0.0.0", port: 8000 }.
+                    properties:
+                      address:
+                        description: Defines the metrics address interface.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the metrics port.
+                        type: integer
+                      tls:
+                        description: |-
+                          TLS holds TLS file config details.
+                          Metrics and health endpoints cannot have same port number when metrics is served over HTTPS.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        type: object
+                    type: object
+                  policy:
+                    description: Policy specifies default policy applied if not overridden
+                      by the user
+                    properties:
+                      applyToIngress:
+                        description: |-
+                          ApplyToIngress determines if the Policies will apply to ingress objects
+                          Contour's default is false.
+                        type: boolean
+                      requestHeaders:
+                        description: RequestHeadersPolicy defines the request headers
+                          set/removed on all routes
+                        properties:
+                          remove:
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      responseHeaders:
+                        description: ResponseHeadersPolicy defines the response headers
+                          set/removed on all routes
+                        properties:
+                          remove:
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  rateLimitService:
+                    description: |-
+                      RateLimitService optionally holds properties of the Rate Limit Service
+                      to be used for global rate limiting.
+                    properties:
+                      defaultGlobalRateLimitPolicy:
+                        description: |-
+                          DefaultGlobalRateLimitPolicy allows setting a default global rate limit policy for every HTTPProxy.
+                          HTTPProxy can overwrite this configuration.
+                        properties:
+                          descriptors:
+                            description: |-
+                              Descriptors defines the list of descriptors that will
+                              be generated and sent to the rate limit service. Each
+                              descriptor contains 1+ key-value pair entries.
+                            items:
+                              description: RateLimitDescriptor defines a list of key-value
+                                pair generators.
+                              properties:
+                                entries:
+                                  description: Entries is the list of key-value pair
+                                    generators.
+                                  items:
+                                    description: |-
+                                      RateLimitDescriptorEntry is a key-value pair generator. Exactly
+                                      one field on this struct must be non-nil.
+                                    properties:
+                                      genericKey:
+                                        description: GenericKey defines a descriptor
+                                          entry with a static key and value.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              Key defines the key of the descriptor entry. If not set, the
+                                              key is set to "generic_key".
+                                            type: string
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - value
+                                        type: object
+                                      remoteAddress:
+                                        description: |-
+                                          RemoteAddress defines a descriptor entry with a key of "remote_address"
+                                          and a value equal to the client's IP address (from x-forwarded-for).
+                                        type: object
+                                      requestHeader:
+                                        description: |-
+                                          RequestHeader defines a descriptor entry that's populated only if
+                                          a given header is present on the request. The descriptor key is static,
+                                          and the descriptor value is equal to the value of the header.
+                                        properties:
+                                          descriptorKey:
+                                            description: DescriptorKey defines the
+                                              key to use on the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                          headerName:
+                                            description: HeaderName defines the name
+                                              of the header to look for on the request.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - descriptorKey
+                                        - headerName
+                                        type: object
+                                      requestHeaderValueMatch:
+                                        description: |-
+                                          RequestHeaderValueMatch defines a descriptor entry that's populated
+                                          if the request's headers match a set of 1+ match criteria. The
+                                          descriptor key is "header_match", and the descriptor value is static.
+                                        properties:
+                                          expectMatch:
+                                            default: true
+                                            description: |-
+                                              ExpectMatch defines whether the request must positively match the match
+                                              criteria in order to generate a descriptor entry (i.e. true), or not
+                                              match the match criteria in order to generate a descriptor entry (i.e. false).
+                                              The default is true.
+                                            type: boolean
+                                          headers:
+                                            description: |-
+                                              Headers is a list of 1+ match criteria to apply against the request
+                                              to determine whether to populate the descriptor entry or not.
+                                            items:
+                                              description: |-
+                                                HeaderMatchCondition specifies how to conditionally match against HTTP
+                                                headers. The Name field is required, only one of Present, NotPresent,
+                                                Contains, NotContains, Exact, NotExact and Regex can be set.
+                                                For negative matching rules only (e.g. NotContains or NotExact) you can set
+                                                TreatMissingAsEmpty.
+                                                IgnoreCase has no effect for Regex.
+                                              properties:
+                                                contains:
+                                                  description: |-
+                                                    Contains specifies a substring that must be present in
+                                                    the header value.
+                                                  type: string
+                                                exact:
+                                                  description: Exact specifies a string
+                                                    that the header value must be
+                                                    equal to.
+                                                  type: string
+                                                ignoreCase:
+                                                  description: |-
+                                                    IgnoreCase specifies that string matching should be case insensitive.
+                                                    Note that this has no effect on the Regex parameter.
+                                                  type: boolean
+                                                name:
+                                                  description: |-
+                                                    Name is the name of the header to match against. Name is required.
+                                                    Header names are case insensitive.
+                                                  type: string
+                                                notcontains:
+                                                  description: |-
+                                                    NotContains specifies a substring that must not be present
+                                                    in the header value.
+                                                  type: string
+                                                notexact:
+                                                  description: |-
+                                                    NoExact specifies a string that the header value must not be
+                                                    equal to. The condition is true if the header has any other value.
+                                                  type: string
+                                                notpresent:
+                                                  description: |-
+                                                    NotPresent specifies that condition is true when the named header
+                                                    is not present. Note that setting NotPresent to false does not
+                                                    make the condition true if the named header is present.
+                                                  type: boolean
+                                                present:
+                                                  description: |-
+                                                    Present specifies that condition is true when the named header
+                                                    is present, regardless of its value. Note that setting Present
+                                                    to false does not make the condition true if the named header
+                                                    is absent.
+                                                  type: boolean
+                                                regex:
+                                                  description: |-
+                                                    Regex specifies a regular expression pattern that must match the header
+                                                    value.
+                                                  type: string
+                                                treatMissingAsEmpty:
+                                                  description: |-
+                                                    TreatMissingAsEmpty specifies if the header match rule specified header
+                                                    does not exist, this header value will be treated as empty. Defaults to false.
+                                                    Unlike the underlying Envoy implementation this is **only** supported for
+                                                    negative matches (e.g. NotContains, NotExact).
+                                                  type: boolean
+                                              required:
+                                              - name
+                                              type: object
+                                            minItems: 1
+                                            type: array
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - value
+                                        type: object
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              required:
+                              - entries
+                              type: object
+                            minItems: 1
+                            type: array
+                          disabled:
+                            description: |-
+                              Disabled configures the HTTPProxy to not use
+                              the default global rate limit policy defined by the Contour configuration.
+                            type: boolean
+                        type: object
+                      domain:
+                        description: Domain is passed to the Rate Limit Service.
+                        type: string
+                      enableResourceExhaustedCode:
+                        description: |-
+                          EnableResourceExhaustedCode enables translating error code 429 to
+                          grpc code RESOURCE_EXHAUSTED. When disabled it's translated to UNAVAILABLE
+                        type: boolean
+                      enableXRateLimitHeaders:
+                        description: |-
+                          EnableXRateLimitHeaders defines whether to include the X-RateLimit
+                          headers X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset
+                          (as defined by the IETF Internet-Draft linked below), on responses
+                          to clients when the Rate Limit Service is consulted for a request.
+                          ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html
+                        type: boolean
+                      extensionService:
+                        description: ExtensionService identifies the extension service
+                          defining the RLS.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      failOpen:
+                        description: |-
+                          FailOpen defines whether to allow requests to proceed when the
+                          Rate Limit Service fails to respond with a valid rate limit
+                          decision within the timeout defined on the extension service.
+                        type: boolean
+                    required:
+                    - extensionService
+                    type: object
+                  tracing:
+                    description: Tracing defines properties for exporting trace data
+                      to OpenTelemetry.
+                    properties:
+                      customTags:
+                        description: CustomTags defines a list of custom tags with
+                          unique tag name.
+                        items:
+                          description: |-
+                            CustomTag defines custom tags with unique tag name
+                            to create tags for the active span.
+                          properties:
+                            literal:
+                              description: |-
+                                Literal is a static custom tag value.
+                                Precisely one of Literal, RequestHeaderName must be set.
+                              type: string
+                            requestHeaderName:
+                              description: |-
+                                RequestHeaderName indicates which request header
+                                the label value is obtained from.
+                                Precisely one of Literal, RequestHeaderName must be set.
+                              type: string
+                            tagName:
+                              description: TagName is the unique name of the custom
+                                tag.
+                              type: string
+                          required:
+                          - tagName
+                          type: object
+                        type: array
+                      extensionService:
+                        description: ExtensionService identifies the extension service
+                          defining the otel-collector.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      includePodDetail:
+                        description: |-
+                          IncludePodDetail defines a flag.
+                          If it is true, contour will add the pod name and namespace to the span of the trace.
+                          the default is true.
+                          Note: The Envoy pods MUST have the HOSTNAME and CONTOUR_NAMESPACE environment variables set for this to work properly.
+                        type: boolean
+                      maxPathTagLength:
+                        description: |-
+                          MaxPathTagLength defines maximum length of the request path
+                          to extract and include in the HttpUrl tag.
+                          contour's default is 256.
+                        format: int32
+                        type: integer
+                      overallSampling:
+                        description: |-
+                          OverallSampling defines the sampling rate of trace data.
+                          contour's default is 100.
+                        type: string
+                      serviceName:
+                        description: |-
+                          ServiceName defines the name for the service.
+                          contour's default is contour.
+                        type: string
+                    required:
+                    - extensionService
+                    type: object
+                  xdsServer:
+                    description: XDSServer contains parameters for the xDS server.
+                    properties:
+                      address:
+                        description: |-
+                          Defines the xDS gRPC API address which Contour will serve.
+                          Contour's default is "0.0.0.0".
+                        minLength: 1
+                        type: string
+                      port:
+                        description: |-
+                          Defines the xDS gRPC API port which Contour will serve.
+                          Contour's default is 8001.
+                        type: integer
+                      tls:
+                        description: |-
+                          TLS holds TLS file config details.
+                          Contour's default is { caFile: "/certs/ca.crt", certFile: "/certs/tls.cert", keyFile: "/certs/tls.key", insecure: false }.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          insecure:
+                            description: Allow serving the xDS gRPC API without TLS.
+                            type: boolean
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ContourDeploymentStatus defines the observed state of a ContourDeployment
+              resource.
+            properties:
+              conditions:
+                description: Conditions describe the current conditions of the ContourDeployment
+                  resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: extensionservices.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: ExtensionService
+    listKind: ExtensionServiceList
+    plural: extensionservices
+    shortNames:
+    - extensionservice
+    - extensionservices
+    singular: extensionservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ExtensionService is the schema for the Contour extension services API.
+          An ExtensionService resource binds a network service to the Contour
+          API so that Contour API features can be implemented by collaborating
+          components.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExtensionServiceSpec defines the desired state of an ExtensionService
+              resource.
+            properties:
+              circuitBreakerPolicy:
+                description: |-
+                  CircuitBreakerPolicy specifies the circuit breaker budget across the extension service.
+                  If defined this overrides the global circuit breaker budget.
+                properties:
+                  maxConnections:
+                    description: The maximum number of connections that a single Envoy
+                      instance allows to the Kubernetes Service; defaults to 1024.
+                    format: int32
+                    type: integer
+                  maxPendingRequests:
+                    description: The maximum number of pending requests that a single
+                      Envoy instance allows to the Kubernetes Service; defaults to
+                      1024.
+                    format: int32
+                    type: integer
+                  maxRequests:
+                    description: The maximum parallel requests a single Envoy instance
+                      allows to the Kubernetes Service; defaults to 1024
+                    format: int32
+                    type: integer
+                  maxRetries:
+                    description: The maximum number of parallel retries a single Envoy
+                      instance allows to the Kubernetes Service; defaults to 3.
+                    format: int32
+                    type: integer
+                  perHostMaxConnections:
+                    description: |-
+                      PerHostMaxConnections is the maximum number of connections
+                      that Envoy will allow to each individual host in a cluster.
+                    format: int32
+                    type: integer
+                type: object
+              loadBalancerPolicy:
+                description: |-
+                  The policy for load balancing GRPC service requests. Note that the
+                  `Cookie` and `RequestHash` load balancing strategies cannot be used
+                  here.
+                properties:
+                  requestHashPolicies:
+                    description: |-
+                      RequestHashPolicies contains a list of hash policies to apply when the
+                      `RequestHash` load balancing strategy is chosen. If an element of the
+                      supplied list of hash policies is invalid, it will be ignored. If the
+                      list of hash policies is empty after validation, the load balancing
+                      strategy will fall back to the default `RoundRobin`.
+                    items:
+                      description: |-
+                        RequestHashPolicy contains configuration for an individual hash policy
+                        on a request attribute.
+                      properties:
+                        hashSourceIP:
+                          description: |-
+                            HashSourceIP should be set to true when request source IP hash based
+                            load balancing is desired. It must be the only hash option field set,
+                            otherwise this request hash policy object will be ignored.
+                          type: boolean
+                        headerHashOptions:
+                          description: |-
+                            HeaderHashOptions should be set when request header hash based load
+                            balancing is desired. It must be the only hash option field set,
+                            otherwise this request hash policy object will be ignored.
+                          properties:
+                            headerName:
+                              description: |-
+                                HeaderName is the name of the HTTP request header that will be used to
+                                calculate the hash key. If the header specified is not present on a
+                                request, no hash will be produced.
+                              minLength: 1
+                              type: string
+                          required:
+                          - headerName
+                          type: object
+                        queryParameterHashOptions:
+                          description: |-
+                            QueryParameterHashOptions should be set when request query parameter hash based load
+                            balancing is desired. It must be the only hash option field set,
+                            otherwise this request hash policy object will be ignored.
+                          properties:
+                            parameterName:
+                              description: |-
+                                ParameterName is the name of the HTTP request query parameter that will be used to
+                                calculate the hash key. If the query parameter specified is not present on a
+                                request, no hash will be produced.
+                              minLength: 1
+                              type: string
+                          required:
+                          - parameterName
+                          type: object
+                        terminal:
+                          description: |-
+                            Terminal is a flag that allows for short-circuiting computing of a hash
+                            for a given request. If set to true, and the request attribute specified
+                            in the attribute hash options is present, no further hash policies will
+                            be used to calculate a hash for the request.
+                          type: boolean
+                      type: object
+                    type: array
+                  strategy:
+                    description: |-
+                      Strategy specifies the policy used to balance requests
+                      across the pool of backend pods. Valid policy names are
+                      `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                      and `RequestHash`. If an unknown strategy name is specified
+                      or no policy is supplied, the default `RoundRobin` policy
+                      is used.
+                    type: string
+                type: object
+              protocol:
+                description: |-
+                  Protocol may be used to specify (or override) the protocol used to reach this Service.
+                  Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
+                enum:
+                - h2
+                - h2c
+                type: string
+              protocolVersion:
+                description: |-
+                  This field sets the version of the GRPC protocol that Envoy uses to
+                  send requests to the extension service. Since Contour always uses the
+                  v3 Envoy API, this is currently fixed at "v3". However, other
+                  protocol options will be available in future.
+                enum:
+                - v3
+                type: string
+              services:
+                description: |-
+                  Services specifies the set of Kubernetes Service resources that
+                  receive GRPC extension API requests.
+                  If no weights are specified for any of the entries in
+                  this array, traffic will be spread evenly across all the
+                  services.
+                  Otherwise, traffic is balanced proportionally to the
+                  Weight field in each entry.
+                items:
+                  description: |-
+                    ExtensionServiceTarget defines an Kubernetes Service to target with
+                    extension service traffic.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of Kubernetes service that will accept service
+                        traffic.
+                      type: string
+                    port:
+                      description: Port (defined as Integer) to proxy traffic to since
+                        a service can have multiple defined.
+                      exclusiveMaximum: true
+                      maximum: 65536
+                      minimum: 1
+                      type: integer
+                    weight:
+                      description: Weight defines proportion of traffic to balance
+                        to the Kubernetes Service.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - port
+                  type: object
+                minItems: 1
+                type: array
+              timeoutPolicy:
+                description: The timeout policy for requests to the services.
+                properties:
+                  idle:
+                    description: |-
+                      Timeout for how long the proxy should wait while there is no activity during single request/response (for HTTP/1.1) or stream (for HTTP/2).
+                      Timeout will not trigger while HTTP/1.1 connection is idle between two consecutive requests.
+                      If not specified, there is no per-route idle timeout, though a connection manager-wide
+                      stream_idle_timeout default of 5m still applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  idleConnection:
+                    description: |-
+                      Timeout for how long connection from the proxy to the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  response:
+                    description: |-
+                      Timeout for receiving a response from the server after processing a request from client.
+                      If not supplied, Envoy's default value of 15s applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                type: object
+              validation:
+                description: UpstreamValidation defines how to verify the backend
+                  service's certificate
+                properties:
+                  caSecret:
+                    description: |-
+                      Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
+                      The secret must contain key named ca.crt.
+                      The name can be optionally prefixed with namespace "namespace/name".
+                      When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                      Max length should be the actual max possible length of a namespaced name (63 + 253 + 1 = 317)
+                    maxLength: 317
+                    minLength: 1
+                    type: string
+                  subjectName:
+                    description: |-
+                      Key which is expected to be present in the 'subjectAltName' of the presented certificate.
+                      Deprecated: migrate to using the plural field subjectNames.
+                    maxLength: 250
+                    minLength: 1
+                    type: string
+                  subjectNames:
+                    description: |-
+                      List of keys, of which at least one is expected to be present in the 'subjectAltName of the
+                      presented certificate.
+                    items:
+                      type: string
+                    maxItems: 8
+                    minItems: 1
+                    type: array
+                required:
+                - caSecret
+                - subjectName
+                type: object
+                x-kubernetes-validations:
+                - message: subjectNames[0] must equal subjectName if set
+                  rule: 'has(self.subjectNames) ? self.subjectNames[0] == self.subjectName
+                    : true'
+            required:
+            - services
+            type: object
+          status:
+            description: |-
+              ExtensionServiceStatus defines the observed state of an
+              ExtensionService resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions contains the current status of the ExtensionService resource.
+                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will not modify any other Conditions set in this block,
+                  in case some other controller wants to add a Condition.
+                items:
+                  description: |-
+                    DetailedCondition is an extension of the normal Kubernetes conditions, with two extra
+                    fields to hold sub-conditions, which provide more detailed reasons for the state (True or False)
+                    of the condition.
+                    `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
+                    `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
+                    Remember that Conditions have a type, a status, and a reason.
+                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
+                    In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
+                    `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
+                    slice in this case.
+                    `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
+                    The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`.
+                    For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
+                    When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
+                    In either case, there may be entries in the `warnings` slice.
+                    Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason
+                    (if there is one and only one entry in total across both the `errors` and `warnings` slices), or
+                    `MultipleReasons` if there is more than one entry.
+                  properties:
+                    errors:
+                      description: |-
+                        Errors contains a slice of relevant error subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: |-
+                        Warnings contains a slice of relevant warning subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant.
+                        An empty slice here indicates no warnings.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: httpproxies.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: HTTPProxy
+    listKind: HTTPProxyList
+    plural: httpproxies
+    shortNames:
+    - proxy
+    - proxies
+    singular: httpproxy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Fully qualified domain name
+      jsonPath: .spec.virtualhost.fqdn
+      name: FQDN
+      type: string
+    - description: Secret with TLS credentials
+      jsonPath: .spec.virtualhost.tls.secretName
+      name: TLS Secret
+      type: string
+    - description: The current status of the HTTPProxy
+      jsonPath: .status.currentStatus
+      name: Status
+      type: string
+    - description: Description of the current status
+      jsonPath: .status.description
+      name: Status Description
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: HTTPProxy is an Ingress CRD specification.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HTTPProxySpec defines the spec of the CRD.
+            properties:
+              includes:
+                description: |-
+                  Includes allow for specific routing configuration to be included from another HTTPProxy,
+                  possibly in another namespace.
+                items:
+                  description: Include describes a set of policies that can be applied
+                    to an HTTPProxy in a namespace.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions are a set of rules that are applied to included HTTPProxies.
+                        In effect, they are added onto the Conditions of included HTTPProxy Route
+                        structs.
+                        When applied, they are merged using AND, with one exception:
+                        There can be only one Prefix MatchCondition per Conditions slice.
+                        More than one Prefix, or contradictory Conditions, will make the
+                        include invalid. Exact and Regex match conditions are not allowed
+                        on includes.
+                      items:
+                        description: |-
+                          MatchCondition are a general holder for matching rules for HTTPProxies.
+                          One of Prefix, Exact, Regex, Header or QueryParameter must be provided.
+                        properties:
+                          exact:
+                            description: |-
+                              Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
+                          header:
+                            description: Header specifies the header condition to
+                              match.
+                            properties:
+                              contains:
+                                description: |-
+                                  Contains specifies a substring that must be present in
+                                  the header value.
+                                type: string
+                              exact:
+                                description: Exact specifies a string that the header
+                                  value must be equal to.
+                                type: string
+                              ignoreCase:
+                                description: |-
+                                  IgnoreCase specifies that string matching should be case insensitive.
+                                  Note that this has no effect on the Regex parameter.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Name is the name of the header to match against. Name is required.
+                                  Header names are case insensitive.
+                                type: string
+                              notcontains:
+                                description: |-
+                                  NotContains specifies a substring that must not be present
+                                  in the header value.
+                                type: string
+                              notexact:
+                                description: |-
+                                  NoExact specifies a string that the header value must not be
+                                  equal to. The condition is true if the header has any other value.
+                                type: string
+                              notpresent:
+                                description: |-
+                                  NotPresent specifies that condition is true when the named header
+                                  is not present. Note that setting NotPresent to false does not
+                                  make the condition true if the named header is present.
+                                type: boolean
+                              present:
+                                description: |-
+                                  Present specifies that condition is true when the named header
+                                  is present, regardless of its value. Note that setting Present
+                                  to false does not make the condition true if the named header
+                                  is absent.
+                                type: boolean
+                              regex:
+                                description: |-
+                                  Regex specifies a regular expression pattern that must match the header
+                                  value.
+                                type: string
+                              treatMissingAsEmpty:
+                                description: |-
+                                  TreatMissingAsEmpty specifies if the header match rule specified header
+                                  does not exist, this header value will be treated as empty. Defaults to false.
+                                  Unlike the underlying Envoy implementation this is **only** supported for
+                                  negative matches (e.g. NotContains, NotExact).
+                                type: boolean
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Prefix defines a prefix match for a request.
+                            type: string
+                          queryParameter:
+                            description: QueryParameter specifies the query parameter
+                              condition to match.
+                            properties:
+                              contains:
+                                description: |-
+                                  Contains specifies a substring that must be present in
+                                  the query parameter value.
+                                type: string
+                              exact:
+                                description: Exact specifies a string that the query
+                                  parameter value must be equal to.
+                                type: string
+                              ignoreCase:
+                                description: |-
+                                  IgnoreCase specifies that string matching should be case insensitive.
+                                  Note that this has no effect on the Regex parameter.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Name is the name of the query parameter to match against. Name is required.
+                                  Query parameter names are case insensitive.
+                                type: string
+                              prefix:
+                                description: Prefix defines a prefix match for the
+                                  query parameter value.
+                                type: string
+                              present:
+                                description: |-
+                                  Present specifies that condition is true when the named query parameter
+                                  is present, regardless of its value. Note that setting Present
+                                  to false does not make the condition true if the named query parameter
+                                  is absent.
+                                type: boolean
+                              regex:
+                                description: |-
+                                  Regex specifies a regular expression pattern that must match the query
+                                  parameter value.
+                                type: string
+                              suffix:
+                                description: Suffix defines a suffix match for a query
+                                  parameter value.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          regex:
+                            description: |-
+                              Regex defines a regex match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      description: Name of the HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              ingressClassName:
+                description: |-
+                  IngressClassName optionally specifies the ingress class to use for this
+                  HTTPProxy. This replaces the deprecated `kubernetes.io/ingress.class`
+                  annotation. For backwards compatibility, when that annotation is set, it
+                  is given precedence over this field.
+                type: string
+              routes:
+                description: Routes are the ingress routes. If TCPProxy is present,
+                  Routes is ignored.
+                items:
+                  description: Route contains the set of routes for a virtual host.
+                  properties:
+                    authPolicy:
+                      description: |-
+                        AuthPolicy updates the authorization policy that was set
+                        on the root HTTPProxy object for client requests that
+                        match this route.
+                      properties:
+                        context:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Context is a set of key/value pairs that are sent to the
+                            authentication server in the check request. If a context
+                            is provided at an enclosing scope, the entries are merged
+                            such that the inner scope overrides matching keys from the
+                            outer scope.
+                          type: object
+                        disabled:
+                          description: |-
+                            When true, this field disables client request authentication
+                            for the scope of the policy.
+                          type: boolean
+                      type: object
+                    conditions:
+                      description: |-
+                        Conditions are a set of rules that are applied to a Route.
+                        When applied, they are merged using AND, with one exception:
+                        There can be only one Prefix, Exact or Regex MatchCondition
+                        per Conditions slice. More than one of these condition types,
+                        or contradictory Conditions, will make the route invalid.
+                      items:
+                        description: |-
+                          MatchCondition are a general holder for matching rules for HTTPProxies.
+                          One of Prefix, Exact, Regex, Header or QueryParameter must be provided.
+                        properties:
+                          exact:
+                            description: |-
+                              Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
+                          header:
+                            description: Header specifies the header condition to
+                              match.
+                            properties:
+                              contains:
+                                description: |-
+                                  Contains specifies a substring that must be present in
+                                  the header value.
+                                type: string
+                              exact:
+                                description: Exact specifies a string that the header
+                                  value must be equal to.
+                                type: string
+                              ignoreCase:
+                                description: |-
+                                  IgnoreCase specifies that string matching should be case insensitive.
+                                  Note that this has no effect on the Regex parameter.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Name is the name of the header to match against. Name is required.
+                                  Header names are case insensitive.
+                                type: string
+                              notcontains:
+                                description: |-
+                                  NotContains specifies a substring that must not be present
+                                  in the header value.
+                                type: string
+                              notexact:
+                                description: |-
+                                  NoExact specifies a string that the header value must not be
+                                  equal to. The condition is true if the header has any other value.
+                                type: string
+                              notpresent:
+                                description: |-
+                                  NotPresent specifies that condition is true when the named header
+                                  is not present. Note that setting NotPresent to false does not
+                                  make the condition true if the named header is present.
+                                type: boolean
+                              present:
+                                description: |-
+                                  Present specifies that condition is true when the named header
+                                  is present, regardless of its value. Note that setting Present
+                                  to false does not make the condition true if the named header
+                                  is absent.
+                                type: boolean
+                              regex:
+                                description: |-
+                                  Regex specifies a regular expression pattern that must match the header
+                                  value.
+                                type: string
+                              treatMissingAsEmpty:
+                                description: |-
+                                  TreatMissingAsEmpty specifies if the header match rule specified header
+                                  does not exist, this header value will be treated as empty. Defaults to false.
+                                  Unlike the underlying Envoy implementation this is **only** supported for
+                                  negative matches (e.g. NotContains, NotExact).
+                                type: boolean
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Prefix defines a prefix match for a request.
+                            type: string
+                          queryParameter:
+                            description: QueryParameter specifies the query parameter
+                              condition to match.
+                            properties:
+                              contains:
+                                description: |-
+                                  Contains specifies a substring that must be present in
+                                  the query parameter value.
+                                type: string
+                              exact:
+                                description: Exact specifies a string that the query
+                                  parameter value must be equal to.
+                                type: string
+                              ignoreCase:
+                                description: |-
+                                  IgnoreCase specifies that string matching should be case insensitive.
+                                  Note that this has no effect on the Regex parameter.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Name is the name of the query parameter to match against. Name is required.
+                                  Query parameter names are case insensitive.
+                                type: string
+                              prefix:
+                                description: Prefix defines a prefix match for the
+                                  query parameter value.
+                                type: string
+                              present:
+                                description: |-
+                                  Present specifies that condition is true when the named query parameter
+                                  is present, regardless of its value. Note that setting Present
+                                  to false does not make the condition true if the named query parameter
+                                  is absent.
+                                type: boolean
+                              regex:
+                                description: |-
+                                  Regex specifies a regular expression pattern that must match the query
+                                  parameter value.
+                                type: string
+                              suffix:
+                                description: Suffix defines a suffix match for a query
+                                  parameter value.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          regex:
+                            description: |-
+                              Regex defines a regex match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
+                        type: object
+                      type: array
+                    cookieRewritePolicies:
+                      description: |-
+                        The policies for rewriting Set-Cookie header attributes. Note that
+                        rewritten cookie names must be unique in this list. Order rewrite
+                        policies are specified in does not matter.
+                      items:
+                        properties:
+                          domainRewrite:
+                            description: |-
+                              DomainRewrite enables rewriting the Set-Cookie Domain element.
+                              If not set, Domain will not be rewritten.
+                            properties:
+                              value:
+                                description: |-
+                                  Value is the value to rewrite the Domain attribute to.
+                                  For now this is required.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          name:
+                            description: Name is the name of the cookie for which
+                              attributes will be rewritten.
+                            maxLength: 4096
+                            minLength: 1
+                            pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                            type: string
+                          pathRewrite:
+                            description: |-
+                              PathRewrite enables rewriting the Set-Cookie Path element.
+                              If not set, Path will not be rewritten.
+                            properties:
+                              value:
+                                description: |-
+                                  Value is the value to rewrite the Path attribute to.
+                                  For now this is required.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          sameSite:
+                            description: |-
+                              SameSite enables rewriting the Set-Cookie SameSite element.
+                              If not set, SameSite attribute will not be rewritten.
+                            enum:
+                            - Strict
+                            - Lax
+                            - None
+                            type: string
+                          secure:
+                            description: |-
+                              Secure enables rewriting the Set-Cookie Secure element.
+                              If not set, Secure attribute will not be rewritten.
+                            type: boolean
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    directResponsePolicy:
+                      description: DirectResponsePolicy returns an arbitrary HTTP
+                        response directly.
+                      properties:
+                        body:
+                          description: |-
+                            Body is the content of the response body.
+                            If this setting is omitted, no body is included in the generated response.
+                            Note: Body is not recommended to set too long
+                            otherwise it can have significant resource usage impacts.
+                          type: string
+                        statusCode:
+                          description: StatusCode is the HTTP response status to be
+                            returned.
+                          maximum: 599
+                          minimum: 200
+                          type: integer
+                      required:
+                      - statusCode
+                      type: object
+                    enableWebsockets:
+                      description: Enables websocket support for the route.
+                      type: boolean
+                    healthCheckPolicy:
+                      description: The health check policy for this route.
+                      properties:
+                        expectedStatuses:
+                          description: |-
+                            The ranges of HTTP response statuses considered healthy. Follow half-open
+                            semantics, i.e. for each range the start is inclusive and the end is exclusive.
+                            Must be within the range [100,600). If not specified, only a 200 response status
+                            is considered healthy.
+                          items:
+                            properties:
+                              end:
+                                description: The end (exclusive) of a range of HTTP
+                                  status codes.
+                                format: int64
+                                maximum: 600
+                                minimum: 101
+                                type: integer
+                              start:
+                                description: The start (inclusive) of a range of HTTP
+                                  status codes.
+                                format: int64
+                                maximum: 599
+                                minimum: 100
+                                type: integer
+                            required:
+                            - end
+                            - start
+                            type: object
+                          type: array
+                        healthyThresholdCount:
+                          description: The number of healthy health checks required
+                            before a host is marked healthy
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        host:
+                          description: |-
+                            The value of the host header in the HTTP health check request.
+                            If left empty (default value), the name "contour-envoy-healthcheck"
+                            will be used.
+                          type: string
+                        intervalSeconds:
+                          description: The interval (seconds) between health checks
+                          format: int64
+                          type: integer
+                        path:
+                          description: HTTP endpoint used to perform health checks
+                            on upstream service
+                          type: string
+                        timeoutSeconds:
+                          description: The time to wait (seconds) for a health check
+                            response
+                          format: int64
+                          type: integer
+                        unhealthyThresholdCount:
+                          description: The number of unhealthy health checks required
+                            before a host is marked unhealthy
+                          format: int64
+                          minimum: 0
+                          type: integer
+                      required:
+                      - path
+                      type: object
+                    internalRedirectPolicy:
+                      description: The policy to define when to handle redirects responses
+                        internally.
+                      properties:
+                        allowCrossSchemeRedirect:
+                          default: Never
+                          description: |-
+                            AllowCrossSchemeRedirect Allow internal redirect to follow a target URI with a different scheme
+                            than the value of x-forwarded-proto.
+                            SafeOnly allows same scheme redirect and safe cross scheme redirect, which means if the downstream
+                            scheme is HTTPS, both HTTPS and HTTP redirect targets are allowed, but if the downstream scheme
+                            is HTTP, only HTTP redirect targets are allowed.
+                          enum:
+                          - Always
+                          - Never
+                          - SafeOnly
+                          type: string
+                        denyRepeatedRouteRedirect:
+                          description: |-
+                            If DenyRepeatedRouteRedirect is true, rejects redirect targets that are pointing to a route that has
+                            been followed by a previous redirect from the current route.
+                          type: boolean
+                        maxInternalRedirects:
+                          description: |-
+                            MaxInternalRedirects An internal redirect is not handled, unless the number of previous internal
+                            redirects that a downstream request has encountered is lower than this value.
+                          format: int32
+                          type: integer
+                        redirectResponseCodes:
+                          description: |-
+                            RedirectResponseCodes If unspecified, only 302 will be treated as internal redirect.
+                            Only 301, 302, 303, 307 and 308 are valid values.
+                          items:
+                            description: RedirectResponseCode is a uint32 type alias
+                              with validation to ensure that the value is valid.
+                            enum:
+                            - 301
+                            - 302
+                            - 303
+                            - 307
+                            - 308
+                            format: int32
+                            type: integer
+                          type: array
+                      type: object
+                    ipAllowPolicy:
+                      description: |-
+                        IPAllowFilterPolicy is a list of ipv4/6 filter rules for which matching
+                        requests should be allowed. All other requests will be denied.
+                        Only one of IPAllowFilterPolicy and IPDenyFilterPolicy can be defined.
+                        The rules defined here override any rules set on the root HTTPProxy.
+                      items:
+                        properties:
+                          cidr:
+                            description: |-
+                              CIDR is a CIDR block of ipv4 or ipv6 addresses to filter on. This can also be
+                              a bare IP address (without a mask) to filter on exactly one address.
+                            type: string
+                          source:
+                            description: |-
+                              Source indicates how to determine the ip address to filter on, and can be
+                              one of two values:
+                               - `Remote` filters on the ip address of the client, accounting for PROXY and
+                                 X-Forwarded-For as needed.
+                               - `Peer` filters on the ip of the network request, ignoring PROXY and
+                                 X-Forwarded-For.
+                            enum:
+                            - Peer
+                            - Remote
+                            type: string
+                        required:
+                        - cidr
+                        - source
+                        type: object
+                      type: array
+                    ipDenyPolicy:
+                      description: |-
+                        IPDenyFilterPolicy is a list of ipv4/6 filter rules for which matching
+                        requests should be denied. All other requests will be allowed.
+                        Only one of IPAllowFilterPolicy and IPDenyFilterPolicy can be defined.
+                        The rules defined here override any rules set on the root HTTPProxy.
+                      items:
+                        properties:
+                          cidr:
+                            description: |-
+                              CIDR is a CIDR block of ipv4 or ipv6 addresses to filter on. This can also be
+                              a bare IP address (without a mask) to filter on exactly one address.
+                            type: string
+                          source:
+                            description: |-
+                              Source indicates how to determine the ip address to filter on, and can be
+                              one of two values:
+                               - `Remote` filters on the ip address of the client, accounting for PROXY and
+                                 X-Forwarded-For as needed.
+                               - `Peer` filters on the ip of the network request, ignoring PROXY and
+                                 X-Forwarded-For.
+                            enum:
+                            - Peer
+                            - Remote
+                            type: string
+                        required:
+                        - cidr
+                        - source
+                        type: object
+                      type: array
+                    jwtVerificationPolicy:
+                      description: The policy for verifying JWTs for requests to this
+                        route.
+                      properties:
+                        disabled:
+                          description: |-
+                            Disabled defines whether to disable all JWT verification for this
+                            route. This can be used to opt specific routes out of the default
+                            JWT provider for the HTTPProxy. At most one of this field or the
+                            "require" field can be specified.
+                          type: boolean
+                        require:
+                          description: |-
+                            Require names a specific JWT provider (defined in the virtual host)
+                            to require for the route. If specified, this field overrides the
+                            default provider if one exists. If this field is not specified,
+                            the default provider will be required if one exists. At most one of
+                            this field or the "disabled" field can be specified.
+                          type: string
+                      type: object
+                    loadBalancerPolicy:
+                      description: The load balancing policy for this route.
+                      properties:
+                        requestHashPolicies:
+                          description: |-
+                            RequestHashPolicies contains a list of hash policies to apply when the
+                            `RequestHash` load balancing strategy is chosen. If an element of the
+                            supplied list of hash policies is invalid, it will be ignored. If the
+                            list of hash policies is empty after validation, the load balancing
+                            strategy will fall back to the default `RoundRobin`.
+                          items:
+                            description: |-
+                              RequestHashPolicy contains configuration for an individual hash policy
+                              on a request attribute.
+                            properties:
+                              hashSourceIP:
+                                description: |-
+                                  HashSourceIP should be set to true when request source IP hash based
+                                  load balancing is desired. It must be the only hash option field set,
+                                  otherwise this request hash policy object will be ignored.
+                                type: boolean
+                              headerHashOptions:
+                                description: |-
+                                  HeaderHashOptions should be set when request header hash based load
+                                  balancing is desired. It must be the only hash option field set,
+                                  otherwise this request hash policy object will be ignored.
+                                properties:
+                                  headerName:
+                                    description: |-
+                                      HeaderName is the name of the HTTP request header that will be used to
+                                      calculate the hash key. If the header specified is not present on a
+                                      request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - headerName
+                                type: object
+                              queryParameterHashOptions:
+                                description: |-
+                                  QueryParameterHashOptions should be set when request query parameter hash based load
+                                  balancing is desired. It must be the only hash option field set,
+                                  otherwise this request hash policy object will be ignored.
+                                properties:
+                                  parameterName:
+                                    description: |-
+                                      ParameterName is the name of the HTTP request query parameter that will be used to
+                                      calculate the hash key. If the query parameter specified is not present on a
+                                      request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - parameterName
+                                type: object
+                              terminal:
+                                description: |-
+                                  Terminal is a flag that allows for short-circuiting computing of a hash
+                                  for a given request. If set to true, and the request attribute specified
+                                  in the attribute hash options is present, no further hash policies will
+                                  be used to calculate a hash for the request.
+                                type: boolean
+                            type: object
+                          type: array
+                        strategy:
+                          description: |-
+                            Strategy specifies the policy used to balance requests
+                            across the pool of backend pods. Valid policy names are
+                            `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                            and `RequestHash`. If an unknown strategy name is specified
+                            or no policy is supplied, the default `RoundRobin` policy
+                            is used.
+                          type: string
+                      type: object
+                    pathRewritePolicy:
+                      description: |-
+                        The policy for rewriting the path of the request URL
+                        after the request has been routed to a Service.
+                      properties:
+                        replacePrefix:
+                          description: ReplacePrefix describes how the path prefix
+                            should be replaced.
+                          items:
+                            description: ReplacePrefix describes a path prefix replacement.
+                            properties:
+                              prefix:
+                                description: |-
+                                  Prefix specifies the URL path prefix to be replaced.
+                                  If Prefix is specified, it must exactly match the MatchCondition
+                                  prefix that is rendered by the chain of including HTTPProxies
+                                  and only that path prefix will be replaced by Replacement.
+                                  This allows HTTPProxies that are included through multiple
+                                  roots to only replace specific path prefixes, leaving others
+                                  unmodified.
+                                  If Prefix is not specified, all routing prefixes rendered
+                                  by the include chain will be replaced.
+                                minLength: 1
+                                type: string
+                              replacement:
+                                description: |-
+                                  Replacement is the string that the routing path prefix
+                                  will be replaced with. This must not be empty.
+                                minLength: 1
+                                type: string
+                            required:
+                            - replacement
+                            type: object
+                          type: array
+                      type: object
+                    permitInsecure:
+                      description: |-
+                        Allow this path to respond to insecure requests over HTTP which are normally
+                        not permitted when a `virtualhost.tls` block is present.
+                      type: boolean
+                    rateLimitPolicy:
+                      description: The policy for rate limiting on the route.
+                      properties:
+                        global:
+                          description: |-
+                            Global defines global rate limiting parameters, i.e. parameters
+                            defining descriptors that are sent to an external rate limit
+                            service (RLS) for a rate limit decision on each request.
+                          properties:
+                            descriptors:
+                              description: |-
+                                Descriptors defines the list of descriptors that will
+                                be generated and sent to the rate limit service. Each
+                                descriptor contains 1+ key-value pair entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of
+                                  key-value pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value
+                                      pair generators.
+                                    items:
+                                      description: |-
+                                        RateLimitDescriptorEntry is a key-value pair generator. Exactly
+                                        one field on this struct must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor
+                                            entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                Key defines the key of the descriptor entry. If not set, the
+                                                key is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value
+                                                of the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - value
+                                          type: object
+                                        remoteAddress:
+                                          description: |-
+                                            RemoteAddress defines a descriptor entry with a key of "remote_address"
+                                            and a value equal to the client's IP address (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: |-
+                                            RequestHeader defines a descriptor entry that's populated only if
+                                            a given header is present on the request. The descriptor key is static,
+                                            and the descriptor value is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the
+                                                key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the
+                                                name of the header to look for on
+                                                the request.
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - descriptorKey
+                                          - headerName
+                                          type: object
+                                        requestHeaderValueMatch:
+                                          description: |-
+                                            RequestHeaderValueMatch defines a descriptor entry that's populated
+                                            if the request's headers match a set of 1+ match criteria. The
+                                            descriptor key is "header_match", and the descriptor value is static.
+                                          properties:
+                                            expectMatch:
+                                              default: true
+                                              description: |-
+                                                ExpectMatch defines whether the request must positively match the match
+                                                criteria in order to generate a descriptor entry (i.e. true), or not
+                                                match the match criteria in order to generate a descriptor entry (i.e. false).
+                                                The default is true.
+                                              type: boolean
+                                            headers:
+                                              description: |-
+                                                Headers is a list of 1+ match criteria to apply against the request
+                                                to determine whether to populate the descriptor entry or not.
+                                              items:
+                                                description: |-
+                                                  HeaderMatchCondition specifies how to conditionally match against HTTP
+                                                  headers. The Name field is required, only one of Present, NotPresent,
+                                                  Contains, NotContains, Exact, NotExact and Regex can be set.
+                                                  For negative matching rules only (e.g. NotContains or NotExact) you can set
+                                                  TreatMissingAsEmpty.
+                                                  IgnoreCase has no effect for Regex.
+                                                properties:
+                                                  contains:
+                                                    description: |-
+                                                      Contains specifies a substring that must be present in
+                                                      the header value.
+                                                    type: string
+                                                  exact:
+                                                    description: Exact specifies a
+                                                      string that the header value
+                                                      must be equal to.
+                                                    type: string
+                                                  ignoreCase:
+                                                    description: |-
+                                                      IgnoreCase specifies that string matching should be case insensitive.
+                                                      Note that this has no effect on the Regex parameter.
+                                                    type: boolean
+                                                  name:
+                                                    description: |-
+                                                      Name is the name of the header to match against. Name is required.
+                                                      Header names are case insensitive.
+                                                    type: string
+                                                  notcontains:
+                                                    description: |-
+                                                      NotContains specifies a substring that must not be present
+                                                      in the header value.
+                                                    type: string
+                                                  notexact:
+                                                    description: |-
+                                                      NoExact specifies a string that the header value must not be
+                                                      equal to. The condition is true if the header has any other value.
+                                                    type: string
+                                                  notpresent:
+                                                    description: |-
+                                                      NotPresent specifies that condition is true when the named header
+                                                      is not present. Note that setting NotPresent to false does not
+                                                      make the condition true if the named header is present.
+                                                    type: boolean
+                                                  present:
+                                                    description: |-
+                                                      Present specifies that condition is true when the named header
+                                                      is present, regardless of its value. Note that setting Present
+                                                      to false does not make the condition true if the named header
+                                                      is absent.
+                                                    type: boolean
+                                                  regex:
+                                                    description: |-
+                                                      Regex specifies a regular expression pattern that must match the header
+                                                      value.
+                                                    type: string
+                                                  treatMissingAsEmpty:
+                                                    description: |-
+                                                      TreatMissingAsEmpty specifies if the header match rule specified header
+                                                      does not exist, this header value will be treated as empty. Defaults to false.
+                                                      Unlike the underlying Envoy implementation this is **only** supported for
+                                                      negative matches (e.g. NotContains, NotExact).
+                                                    type: boolean
+                                                required:
+                                                - name
+                                                type: object
+                                              minItems: 1
+                                              type: array
+                                            value:
+                                              description: Value defines the value
+                                                of the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - value
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                required:
+                                - entries
+                                type: object
+                              minItems: 1
+                              type: array
+                            disabled:
+                              description: |-
+                                Disabled configures the HTTPProxy to not use
+                                the default global rate limit policy defined by the Contour configuration.
+                              type: boolean
+                          type: object
+                        local:
+                          description: |-
+                            Local defines local rate limiting parameters, i.e. parameters
+                            for rate limiting that occurs within each Envoy pod as requests
+                            are handled.
+                          properties:
+                            burst:
+                              description: |-
+                                Burst defines the number of requests above the requests per
+                                unit that should be allowed within a short period of time.
+                              format: int32
+                              type: integer
+                            requests:
+                              description: |-
+                                Requests defines how many requests per unit of time should
+                                be allowed before rate limiting occurs.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            responseHeadersToAdd:
+                              description: |-
+                                ResponseHeadersToAdd is an optional list of response headers to
+                                set when a request is rate-limited.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            responseStatusCode:
+                              description: |-
+                                ResponseStatusCode is the HTTP status code to use for responses
+                                to rate-limited requests. Codes must be in the 400-599 range
+                                (inclusive). If not specified, the Envoy default of 429 (Too
+                                Many Requests) is used.
+                              format: int32
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            unit:
+                              description: |-
+                                Unit defines the period of time within which requests
+                                over the limit will be rate limited. Valid values are
+                                "second", "minute" and "hour".
+                              enum:
+                              - second
+                              - minute
+                              - hour
+                              type: string
+                          required:
+                          - requests
+                          - unit
+                          type: object
+                      type: object
+                    requestHeadersPolicy:
+                      description: |-
+                        The policy for managing request headers during proxying.
+                        You may dynamically rewrite the Host header to be forwarded
+                        upstream to the content of a request header using
+                        the below format "%REQ(X-Header-Name)%". If the value of the header
+                        is empty, it is ignored.
+                        *NOTE: Pay attention to the potential security implications of using this option.
+                        Provided header must come from trusted source.
+                        **NOTE: The header rewrite is only done while forwarding and has no bearing
+                        on the routing decision.
+                      properties:
+                        remove:
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          description: |-
+                            Set specifies a list of HTTP header values that will be set in the HTTP header.
+                            If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                          items:
+                            description: HeaderValue represents a header name/value
+                              pair
+                            properties:
+                              name:
+                                description: Name represents a key of a header
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value represents the value of a header
+                                  specified by a key
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    requestRedirectPolicy:
+                      description: RequestRedirectPolicy defines an HTTP redirection.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is the precise hostname to be used in the value of the `Location`
+                            header in the response.
+                            When empty, the hostname of the request is used.
+                            No wildcards are allowed.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        path:
+                          description: |-
+                            Path allows for redirection to a different path from the
+                            original on the request. The path must start with a
+                            leading slash.
+                            Note: Only one of Path or Prefix can be defined.
+                          pattern: ^\/.*$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the port to be used in the value of the `Location`
+                            header in the response.
+                            When empty, port (if specified) of the request is used.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        prefix:
+                          description: |-
+                            Prefix defines the value to swap the matched prefix or path with.
+                            The prefix must start with a leading slash.
+                            Note: Only one of Path or Prefix can be defined.
+                          pattern: ^\/.*$
+                          type: string
+                        scheme:
+                          description: |-
+                            Scheme is the scheme to be used in the value of the `Location`
+                            header in the response.
+                            When empty, the scheme of the request is used.
+                          enum:
+                          - http
+                          - https
+                          type: string
+                        statusCode:
+                          default: 302
+                          description: StatusCode is the HTTP status code to be used
+                            in response.
+                          enum:
+                          - 301
+                          - 302
+                          - 303
+                          - 307
+                          - 308
+                          format: int32
+                          type: integer
+                      type: object
+                    responseHeadersPolicy:
+                      description: |-
+                        The policy for managing response headers during proxying.
+                        Rewriting the 'Host' header is not supported.
+                      properties:
+                        remove:
+                          description: Remove specifies a list of HTTP header names
+                            to remove.
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          description: |-
+                            Set specifies a list of HTTP header values that will be set in the HTTP header.
+                            If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                          items:
+                            description: HeaderValue represents a header name/value
+                              pair
+                            properties:
+                              name:
+                                description: Name represents a key of a header
+                                minLength: 1
+                                type: string
+                              value:
+                                description: Value represents the value of a header
+                                  specified by a key
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    retryPolicy:
+                      description: The retry policy for this route.
+                      properties:
+                        count:
+                          default: 1
+                          description: |-
+                            NumRetries is maximum allowed number of retries.
+                            If set to -1, then retries are disabled.
+                            If set to 0 or not supplied, the value is set
+                            to the Envoy default of 1.
+                          format: int64
+                          minimum: -1
+                          type: integer
+                        perTryTimeout:
+                          description: |-
+                            PerTryTimeout specifies the timeout per retry attempt.
+                            Ignored if NumRetries is not supplied.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        retriableStatusCodes:
+                          description: |-
+                            RetriableStatusCodes specifies the HTTP status codes that should be retried.
+                            This field is only respected when you include `retriable-status-codes` in the `RetryOn` field.
+                          items:
+                            format: int32
+                            type: integer
+                          type: array
+                        retryOn:
+                          description: |-
+                            RetryOn specifies the conditions on which to retry a request.
+                            Supported [HTTP conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on):
+                            - `5xx`
+                            - `gateway-error`
+                            - `reset`
+                            - `reset-before-request`
+                            - `connect-failure`
+                            - `envoy-ratelimited`
+                            - `retriable-4xx`
+                            - `refused-stream`
+                            - `retriable-status-codes`
+                            - `retriable-headers`
+                            - `http3-post-connect-failure`
+                            Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
+                            - `cancelled`
+                            - `deadline-exceeded`
+                            - `internal`
+                            - `resource-exhausted`
+                            - `unavailable`
+                          items:
+                            description: RetryOn is a string type alias with validation
+                              to ensure that the value is valid.
+                            enum:
+                            - 5xx
+                            - gateway-error
+                            - reset
+                            - reset-before-request
+                            - connect-failure
+                            - envoy-ratelimited
+                            - retriable-4xx
+                            - refused-stream
+                            - retriable-status-codes
+                            - retriable-headers
+                            - http3-post-connect-failure
+                            - cancelled
+                            - deadline-exceeded
+                            - internal
+                            - resource-exhausted
+                            - unavailable
+                            type: string
+                          type: array
+                      type: object
+                    services:
+                      description: Services are the services to proxy traffic.
+                      items:
+                        description: Service defines an Kubernetes Service to proxy
+                          traffic.
+                        properties:
+                          cookieRewritePolicies:
+                            description: The policies for rewriting Set-Cookie header
+                              attributes.
+                            items:
+                              properties:
+                                domainRewrite:
+                                  description: |-
+                                    DomainRewrite enables rewriting the Set-Cookie Domain element.
+                                    If not set, Domain will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: |-
+                                        Value is the value to rewrite the Domain attribute to.
+                                        For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                name:
+                                  description: Name is the name of the cookie for
+                                    which attributes will be rewritten.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                  type: string
+                                pathRewrite:
+                                  description: |-
+                                    PathRewrite enables rewriting the Set-Cookie Path element.
+                                    If not set, Path will not be rewritten.
+                                  properties:
+                                    value:
+                                      description: |-
+                                        Value is the value to rewrite the Path attribute to.
+                                        For now this is required.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                sameSite:
+                                  description: |-
+                                    SameSite enables rewriting the Set-Cookie SameSite element.
+                                    If not set, SameSite attribute will not be rewritten.
+                                  enum:
+                                  - Strict
+                                  - Lax
+                                  - None
+                                  type: string
+                                secure:
+                                  description: |-
+                                    Secure enables rewriting the Set-Cookie Secure element.
+                                    If not set, Secure attribute will not be rewritten.
+                                  type: boolean
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          healthPort:
+                            description: |-
+                              HealthPort is the port for this service healthcheck.
+                              If not specified, Port is used for service healthchecks.
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          mirror:
+                            description: |-
+                              If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+                              If Mirror is true, then fractional mirroring can be enabled by optionally setting the Weight
+                              field. Legal values for Weight are 1-100. Omitting the Weight field will result in 100% mirroring.
+                              NOTE: Setting Weight explicitly to 0 will unexpectedly result in 100% traffic mirroring. This
+                              occurs since we cannot distinguish omitted fields from those explicitly set to their default
+                              values
+                            type: boolean
+                          name:
+                            description: |-
+                              Name is the name of Kubernetes service to proxy traffic.
+                              Names defined here will be used to look up corresponding endpoints which contain the ips to route.
+                            type: string
+                          port:
+                            description: Port (defined as Integer) to proxy traffic
+                              to since a service can have multiple defined.
+                            exclusiveMaximum: true
+                            maximum: 65536
+                            minimum: 1
+                            type: integer
+                          protocol:
+                            description: |-
+                              Protocol may be used to specify (or override) the protocol used to reach this Service.
+                              Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                            enum:
+                            - h2
+                            - h2c
+                            - tls
+                            type: string
+                          requestHeadersPolicy:
+                            description: The policy for managing request headers during
+                              proxying.
+                            properties:
+                              remove:
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                description: |-
+                                  Set specifies a list of HTTP header values that will be set in the HTTP header.
+                                  If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a
+                                        header specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          responseHeadersPolicy:
+                            description: |-
+                              The policy for managing response headers during proxying.
+                              Rewriting the 'Host' header is not supported.
+                            properties:
+                              remove:
+                                description: Remove specifies a list of HTTP header
+                                  names to remove.
+                                items:
+                                  type: string
+                                type: array
+                              set:
+                                description: |-
+                                  Set specifies a list of HTTP header values that will be set in the HTTP header.
+                                  If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a
+                                        header specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          slowStartPolicy:
+                            description: Slow start will gradually increase amount
+                              of traffic to a newly added endpoint.
+                            properties:
+                              aggression:
+                                default: "1.0"
+                                description: |-
+                                  The speed of traffic increase over the slow start window.
+                                  Defaults to 1.0, so that endpoint would get linearly increasing amount of traffic.
+                                  When increasing the value for this parameter, the speed of traffic ramp-up increases non-linearly.
+                                  The value of aggression parameter should be greater than 0.0.
+                                  More info: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/slow_start
+                                pattern: ^([0-9]+([.][0-9]+)?|[.][0-9]+)$
+                                type: string
+                              minWeightPercent:
+                                default: 10
+                                description: |-
+                                  The minimum or starting percentage of traffic to send to new endpoints.
+                                  A non-zero value helps avoid a too small initial weight, which may cause endpoints in slow start mode to receive no traffic in the beginning of the slow start window.
+                                  If not specified, the default is 10%.
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                              window:
+                                description: |-
+                                  The duration of slow start window.
+                                  Duration is expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                                  Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                                pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                                type: string
+                            required:
+                            - window
+                            type: object
+                          validation:
+                            description: UpstreamValidation defines how to verify
+                              the backend service's certificate
+                            properties:
+                              caSecret:
+                                description: |-
+                                  Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
+                                  The secret must contain key named ca.crt.
+                                  The name can be optionally prefixed with namespace "namespace/name".
+                                  When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                                  Max length should be the actual max possible length of a namespaced name (63 + 253 + 1 = 317)
+                                maxLength: 317
+                                minLength: 1
+                                type: string
+                              subjectName:
+                                description: |-
+                                  Key which is expected to be present in the 'subjectAltName' of the presented certificate.
+                                  Deprecated: migrate to using the plural field subjectNames.
+                                maxLength: 250
+                                minLength: 1
+                                type: string
+                              subjectNames:
+                                description: |-
+                                  List of keys, of which at least one is expected to be present in the 'subjectAltName of the
+                                  presented certificate.
+                                items:
+                                  type: string
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                            required:
+                            - caSecret
+                            - subjectName
+                            type: object
+                            x-kubernetes-validations:
+                            - message: subjectNames[0] must equal subjectName if set
+                              rule: 'has(self.subjectNames) ? self.subjectNames[0]
+                                == self.subjectName : true'
+                          weight:
+                            description: Weight defines percentage of traffic to balance
+                              traffic
+                            format: int64
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        - port
+                        type: object
+                      type: array
+                    timeoutPolicy:
+                      description: The timeout policy for this route.
+                      properties:
+                        idle:
+                          description: |-
+                            Timeout for how long the proxy should wait while there is no activity during single request/response (for HTTP/1.1) or stream (for HTTP/2).
+                            Timeout will not trigger while HTTP/1.1 connection is idle between two consecutive requests.
+                            If not specified, there is no per-route idle timeout, though a connection manager-wide
+                            stream_idle_timeout default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: |-
+                            Timeout for how long connection from the proxy to the upstream service is kept when there are no active requests.
+                            If not supplied, Envoy's default value of 1h applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        response:
+                          description: |-
+                            Timeout for receiving a response from the server after processing a request from client.
+                            If not supplied, Envoy's default value of 15s applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              tcpproxy:
+                description: TCPProxy holds TCP proxy information.
+                properties:
+                  healthCheckPolicy:
+                    description: The health check policy for this tcp proxy
+                    properties:
+                      healthyThresholdCount:
+                        description: The number of healthy health checks required
+                          before a host is marked healthy
+                        format: int32
+                        type: integer
+                      intervalSeconds:
+                        description: The interval (seconds) between health checks
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: The time to wait (seconds) for a health check
+                          response
+                        format: int64
+                        type: integer
+                      unhealthyThresholdCount:
+                        description: The number of unhealthy health checks required
+                          before a host is marked unhealthy
+                        format: int32
+                        type: integer
+                    type: object
+                  include:
+                    description: Include specifies that this tcpproxy should be delegated
+                      to another HTTPProxy.
+                    properties:
+                      name:
+                        description: Name of the child HTTPProxy
+                        type: string
+                      namespace:
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  includes:
+                    description: |-
+                      IncludesDeprecated allow for specific routing configuration to be appended to another HTTPProxy in another namespace.
+                      Exists due to a mistake when developing HTTPProxy and the field was marked plural
+                      when it should have been singular. This field should stay to not break backwards compatibility to v1 users.
+                    properties:
+                      name:
+                        description: Name of the child HTTPProxy
+                        type: string
+                      namespace:
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  loadBalancerPolicy:
+                    description: |-
+                      The load balancing policy for the backend services. Note that the
+                      `Cookie` and `RequestHash` load balancing strategies cannot be used
+                      here.
+                    properties:
+                      requestHashPolicies:
+                        description: |-
+                          RequestHashPolicies contains a list of hash policies to apply when the
+                          `RequestHash` load balancing strategy is chosen. If an element of the
+                          supplied list of hash policies is invalid, it will be ignored. If the
+                          list of hash policies is empty after validation, the load balancing
+                          strategy will fall back to the default `RoundRobin`.
+                        items:
+                          description: |-
+                            RequestHashPolicy contains configuration for an individual hash policy
+                            on a request attribute.
+                          properties:
+                            hashSourceIP:
+                              description: |-
+                                HashSourceIP should be set to true when request source IP hash based
+                                load balancing is desired. It must be the only hash option field set,
+                                otherwise this request hash policy object will be ignored.
+                              type: boolean
+                            headerHashOptions:
+                              description: |-
+                                HeaderHashOptions should be set when request header hash based load
+                                balancing is desired. It must be the only hash option field set,
+                                otherwise this request hash policy object will be ignored.
+                              properties:
+                                headerName:
+                                  description: |-
+                                    HeaderName is the name of the HTTP request header that will be used to
+                                    calculate the hash key. If the header specified is not present on a
+                                    request, no hash will be produced.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - headerName
+                              type: object
+                            queryParameterHashOptions:
+                              description: |-
+                                QueryParameterHashOptions should be set when request query parameter hash based load
+                                balancing is desired. It must be the only hash option field set,
+                                otherwise this request hash policy object will be ignored.
+                              properties:
+                                parameterName:
+                                  description: |-
+                                    ParameterName is the name of the HTTP request query parameter that will be used to
+                                    calculate the hash key. If the query parameter specified is not present on a
+                                    request, no hash will be produced.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - parameterName
+                              type: object
+                            terminal:
+                              description: |-
+                                Terminal is a flag that allows for short-circuiting computing of a hash
+                                for a given request. If set to true, and the request attribute specified
+                                in the attribute hash options is present, no further hash policies will
+                                be used to calculate a hash for the request.
+                              type: boolean
+                          type: object
+                        type: array
+                      strategy:
+                        description: |-
+                          Strategy specifies the policy used to balance requests
+                          across the pool of backend pods. Valid policy names are
+                          `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                          and `RequestHash`. If an unknown strategy name is specified
+                          or no policy is supplied, the default `RoundRobin` policy
+                          is used.
+                        type: string
+                    type: object
+                  services:
+                    description: Services are the services to proxy traffic
+                    items:
+                      description: Service defines an Kubernetes Service to proxy
+                        traffic.
+                      properties:
+                        cookieRewritePolicies:
+                          description: The policies for rewriting Set-Cookie header
+                            attributes.
+                          items:
+                            properties:
+                              domainRewrite:
+                                description: |-
+                                  DomainRewrite enables rewriting the Set-Cookie Domain element.
+                                  If not set, Domain will not be rewritten.
+                                properties:
+                                  value:
+                                    description: |-
+                                      Value is the value to rewrite the Domain attribute to.
+                                      For now this is required.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                - value
+                                type: object
+                              name:
+                                description: Name is the name of the cookie for which
+                                  attributes will be rewritten.
+                                maxLength: 4096
+                                minLength: 1
+                                pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                type: string
+                              pathRewrite:
+                                description: |-
+                                  PathRewrite enables rewriting the Set-Cookie Path element.
+                                  If not set, Path will not be rewritten.
+                                properties:
+                                  value:
+                                    description: |-
+                                      Value is the value to rewrite the Path attribute to.
+                                      For now this is required.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                    type: string
+                                required:
+                                - value
+                                type: object
+                              sameSite:
+                                description: |-
+                                  SameSite enables rewriting the Set-Cookie SameSite element.
+                                  If not set, SameSite attribute will not be rewritten.
+                                enum:
+                                - Strict
+                                - Lax
+                                - None
+                                type: string
+                              secure:
+                                description: |-
+                                  Secure enables rewriting the Set-Cookie Secure element.
+                                  If not set, Secure attribute will not be rewritten.
+                                type: boolean
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        healthPort:
+                          description: |-
+                            HealthPort is the port for this service healthcheck.
+                            If not specified, Port is used for service healthchecks.
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        mirror:
+                          description: |-
+                            If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+                            If Mirror is true, then fractional mirroring can be enabled by optionally setting the Weight
+                            field. Legal values for Weight are 1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly result in 100% traffic mirroring. This
+                            occurs since we cannot distinguish omitted fields from those explicitly set to their default
+                            values
+                          type: boolean
+                        name:
+                          description: |-
+                            Name is the name of Kubernetes service to proxy traffic.
+                            Names defined here will be used to look up corresponding endpoints which contain the ips to route.
+                          type: string
+                        port:
+                          description: Port (defined as Integer) to proxy traffic
+                            to since a service can have multiple defined.
+                          exclusiveMaximum: true
+                          maximum: 65536
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: |-
+                            Protocol may be used to specify (or override) the protocol used to reach this Service.
+                            Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                          enum:
+                          - h2
+                          - h2c
+                          - tls
+                          type: string
+                        requestHeadersPolicy:
+                          description: The policy for managing request headers during
+                            proxying.
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: |-
+                                Set specifies a list of HTTP header values that will be set in the HTTP header.
+                                If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        responseHeadersPolicy:
+                          description: |-
+                            The policy for managing response headers during proxying.
+                            Rewriting the 'Host' header is not supported.
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: |-
+                                Set specifies a list of HTTP header values that will be set in the HTTP header.
+                                If the header does not exist it will be added, otherwise it will be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        slowStartPolicy:
+                          description: Slow start will gradually increase amount of
+                            traffic to a newly added endpoint.
+                          properties:
+                            aggression:
+                              default: "1.0"
+                              description: |-
+                                The speed of traffic increase over the slow start window.
+                                Defaults to 1.0, so that endpoint would get linearly increasing amount of traffic.
+                                When increasing the value for this parameter, the speed of traffic ramp-up increases non-linearly.
+                                The value of aggression parameter should be greater than 0.0.
+                                More info: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/slow_start
+                              pattern: ^([0-9]+([.][0-9]+)?|[.][0-9]+)$
+                              type: string
+                            minWeightPercent:
+                              default: 10
+                              description: |-
+                                The minimum or starting percentage of traffic to send to new endpoints.
+                                A non-zero value helps avoid a too small initial weight, which may cause endpoints in slow start mode to receive no traffic in the beginning of the slow start window.
+                                If not specified, the default is 10%.
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                            window:
+                              description: |-
+                                The duration of slow start window.
+                                Duration is expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                                Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                              pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                              type: string
+                          required:
+                          - window
+                          type: object
+                        validation:
+                          description: UpstreamValidation defines how to verify the
+                            backend service's certificate
+                          properties:
+                            caSecret:
+                              description: |-
+                                Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
+                                The secret must contain key named ca.crt.
+                                The name can be optionally prefixed with namespace "namespace/name".
+                                When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                                Max length should be the actual max possible length of a namespaced name (63 + 253 + 1 = 317)
+                              maxLength: 317
+                              minLength: 1
+                              type: string
+                            subjectName:
+                              description: |-
+                                Key which is expected to be present in the 'subjectAltName' of the presented certificate.
+                                Deprecated: migrate to using the plural field subjectNames.
+                              maxLength: 250
+                              minLength: 1
+                              type: string
+                            subjectNames:
+                              description: |-
+                                List of keys, of which at least one is expected to be present in the 'subjectAltName of the
+                                presented certificate.
+                              items:
+                                type: string
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          required:
+                          - caSecret
+                          - subjectName
+                          type: object
+                          x-kubernetes-validations:
+                          - message: subjectNames[0] must equal subjectName if set
+                            rule: 'has(self.subjectNames) ? self.subjectNames[0] ==
+                              self.subjectName : true'
+                        weight:
+                          description: Weight defines percentage of traffic to balance
+                            traffic
+                          format: int64
+                          minimum: 0
+                          type: integer
+                      required:
+                      - name
+                      - port
+                      type: object
+                    type: array
+                type: object
+              virtualhost:
+                description: |-
+                  Virtualhost appears at most once. If it is present, the object is considered
+                  to be a "root" HTTPProxy.
+                properties:
+                  authorization:
+                    description: |-
+                      This field configures an extension service to perform
+                      authorization for this virtual host. Authorization can
+                      only be configured on virtual hosts that have TLS enabled.
+                      If the TLS configuration requires client certificate
+                      validation, the client certificate is always included in the
+                      authentication check request.
+                    properties:
+                      authPolicy:
+                        description: |-
+                          AuthPolicy sets a default authorization policy for client requests.
+                          This policy will be used unless overridden by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Context is a set of key/value pairs that are sent to the
+                              authentication server in the check request. If a context
+                              is provided at an enclosing scope, the entries are merged
+                              such that the inner scope overrides matching keys from the
+                              outer scope.
+                            type: object
+                          disabled:
+                            description: |-
+                              When true, this field disables client request authentication
+                              for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: |-
+                              API version of the referent.
+                              If this field is not specified, the default "projectcontour.io/v1alpha1" will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              If this field is not specifies, the namespace of the resource that targets the referent will be used.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: |-
+                          If FailOpen is true, the client request is forwarded to the upstream service
+                          even if the authorization server fails to respond. This field should not be
+                          set in most cases. It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: |-
+                          ResponseTimeout configures maximum time to wait for a check response from the authorization server.
+                          Timeout durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                          The string "infinity" is also a valid input and specifies no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
+                  corsPolicy:
+                    description: Specifies the cross-origin policy to apply to the
+                      VirtualHost.
+                    properties:
+                      allowCredentials:
+                        description: Specifies whether the resource allows credentials.
+                        type: boolean
+                      allowHeaders:
+                        description: AllowHeaders specifies the content for the *access-control-allow-headers*
+                          header.
+                        items:
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
+                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                          type: string
+                        minItems: 1
+                        type: array
+                      allowMethods:
+                        description: AllowMethods specifies the content for the *access-control-allow-methods*
+                          header.
+                        items:
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
+                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                          type: string
+                        minItems: 1
+                        type: array
+                      allowOrigin:
+                        description: |-
+                          AllowOrigin specifies the origins that will be allowed to do CORS requests.
+                          Allowed values include "*" which signifies any origin is allowed, an exact
+                          origin of the form "scheme://host[:port]" (where port is optional), or a valid
+                          regex pattern.
+                          Note that regex patterns are validated and a simple "glob" pattern (e.g. *.foo.com)
+                          will be rejected or produce unexpected matches when applied as a regex.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                      allowPrivateNetwork:
+                        description: |-
+                          AllowPrivateNetwork specifies whether to allow private network requests.
+                          See https://developer.chrome.com/blog/private-network-access-preflight.
+                        type: boolean
+                      exposeHeaders:
+                        description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
+                          header.
+                        items:
+                          description: CORSHeaderValue specifies the value of the
+                            string headers returned by a cross-domain request.
+                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                          type: string
+                        minItems: 1
+                        type: array
+                      maxAge:
+                        description: |-
+                          MaxAge indicates for how long the results of a preflight request can be cached.
+                          MaxAge durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                          Only positive values are allowed while 0 disables the cache requiring a preflight OPTIONS
+                          check for all cross-origin requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
+                        type: string
+                    required:
+                    - allowMethods
+                    - allowOrigin
+                    type: object
+                  fqdn:
+                    description: |-
+                      The fully qualified domain name of the root of the ingress tree
+                      all leaves of the DAG rooted at this object relate to the fqdn.
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  ipAllowPolicy:
+                    description: |-
+                      IPAllowFilterPolicy is a list of ipv4/6 filter rules for which matching
+                      requests should be allowed. All other requests will be denied.
+                      Only one of IPAllowFilterPolicy and IPDenyFilterPolicy can be defined.
+                      The rules defined here may be overridden in a Route.
+                    items:
+                      properties:
+                        cidr:
+                          description: |-
+                            CIDR is a CIDR block of ipv4 or ipv6 addresses to filter on. This can also be
+                            a bare IP address (without a mask) to filter on exactly one address.
+                          type: string
+                        source:
+                          description: |-
+                            Source indicates how to determine the ip address to filter on, and can be
+                            one of two values:
+                             - `Remote` filters on the ip address of the client, accounting for PROXY and
+                               X-Forwarded-For as needed.
+                             - `Peer` filters on the ip of the network request, ignoring PROXY and
+                               X-Forwarded-For.
+                          enum:
+                          - Peer
+                          - Remote
+                          type: string
+                      required:
+                      - cidr
+                      - source
+                      type: object
+                    type: array
+                  ipDenyPolicy:
+                    description: |-
+                      IPDenyFilterPolicy is a list of ipv4/6 filter rules for which matching
+                      requests should be denied. All other requests will be allowed.
+                      Only one of IPAllowFilterPolicy and IPDenyFilterPolicy can be defined.
+                      The rules defined here may be overridden in a Route.
+                    items:
+                      properties:
+                        cidr:
+                          description: |-
+                            CIDR is a CIDR block of ipv4 or ipv6 addresses to filter on. This can also be
+                            a bare IP address (without a mask) to filter on exactly one address.
+                          type: string
+                        source:
+                          description: |-
+                            Source indicates how to determine the ip address to filter on, and can be
+                            one of two values:
+                             - `Remote` filters on the ip address of the client, accounting for PROXY and
+                               X-Forwarded-For as needed.
+                             - `Peer` filters on the ip of the network request, ignoring PROXY and
+                               X-Forwarded-For.
+                          enum:
+                          - Peer
+                          - Remote
+                          type: string
+                      required:
+                      - cidr
+                      - source
+                      type: object
+                    type: array
+                  jwtProviders:
+                    description: Providers to use for verifying JSON Web Tokens (JWTs)
+                      on the virtual host.
+                    items:
+                      description: JWTProvider defines how to verify JWTs on requests.
+                      properties:
+                        audiences:
+                          description: |-
+                            Audiences that JWTs are allowed to have in the "aud" field.
+                            If not provided, JWT audiences are not checked.
+                          items:
+                            type: string
+                          type: array
+                        default:
+                          description: |-
+                            Whether the provider should apply to all
+                            routes in the HTTPProxy/its includes by
+                            default. At most one provider can be marked
+                            as the default. If no provider is marked
+                            as the default, individual routes must explicitly
+                            identify the provider they require.
+                          type: boolean
+                        forwardJWT:
+                          description: |-
+                            Whether the JWT should be forwarded to the backend
+                            service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
+                        issuer:
+                          description: |-
+                            Issuer that JWTs are required to have in the "iss" field.
+                            If not provided, JWT issuers are not checked.
+                          type: string
+                        name:
+                          description: Unique name for the provider.
+                          minLength: 1
+                          type: string
+                        remoteJWKS:
+                          description: Remote JWKS to use for verifying JWT signatures.
+                          properties:
+                            cacheDuration:
+                              description: |-
+                                How long to cache the JWKS locally. If not specified,
+                                Envoy's default of 5m applies.
+                              pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                              type: string
+                            dnsLookupFamily:
+                              description: |-
+                                The DNS IP address resolution policy for the JWKS URI.
+                                When configured as "v4", the DNS resolver will only perform a lookup
+                                for addresses in the IPv4 family. If "v6" is configured, the DNS resolver
+                                will only perform a lookup for addresses in the IPv6 family.
+                                If "all" is configured, the DNS resolver
+                                will perform a lookup for addresses in both the IPv4 and IPv6 family.
+                                If "auto" is configured, the DNS resolver will first perform a lookup
+                                for addresses in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide setting defined
+                                in the config file or ContourConfiguration applies (defaults to "auto").
+                                See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                                for more information.
+                              enum:
+                              - auto
+                              - v4
+                              - v6
+                              type: string
+                            timeout:
+                              description: |-
+                                How long to wait for a response from the URI.
+                                If not specified, a default of 1s applies.
+                              pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+)$
+                              type: string
+                            uri:
+                              description: The URI for the JWKS.
+                              minLength: 1
+                              type: string
+                            validation:
+                              description: UpstreamValidation defines how to verify
+                                the JWKS's TLS certificate.
+                              properties:
+                                caSecret:
+                                  description: |-
+                                    Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
+                                    The secret must contain key named ca.crt.
+                                    The name can be optionally prefixed with namespace "namespace/name".
+                                    When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                                    Max length should be the actual max possible length of a namespaced name (63 + 253 + 1 = 317)
+                                  maxLength: 317
+                                  minLength: 1
+                                  type: string
+                                subjectName:
+                                  description: |-
+                                    Key which is expected to be present in the 'subjectAltName' of the presented certificate.
+                                    Deprecated: migrate to using the plural field subjectNames.
+                                  maxLength: 250
+                                  minLength: 1
+                                  type: string
+                                subjectNames:
+                                  description: |-
+                                    List of keys, of which at least one is expected to be present in the 'subjectAltName of the
+                                    presented certificate.
+                                  items:
+                                    type: string
+                                  maxItems: 8
+                                  minItems: 1
+                                  type: array
+                              required:
+                              - caSecret
+                              - subjectName
+                              type: object
+                              x-kubernetes-validations:
+                              - message: subjectNames[0] must equal subjectName if
+                                  set
+                                rule: 'has(self.subjectNames) ? self.subjectNames[0]
+                                  == self.subjectName : true'
+                          required:
+                          - uri
+                          type: object
+                      required:
+                      - name
+                      - remoteJWKS
+                      type: object
+                    type: array
+                  rateLimitPolicy:
+                    description: The policy for rate limiting on the virtual host.
+                    properties:
+                      global:
+                        description: |-
+                          Global defines global rate limiting parameters, i.e. parameters
+                          defining descriptors that are sent to an external rate limit
+                          service (RLS) for a rate limit decision on each request.
+                        properties:
+                          descriptors:
+                            description: |-
+                              Descriptors defines the list of descriptors that will
+                              be generated and sent to the rate limit service. Each
+                              descriptor contains 1+ key-value pair entries.
+                            items:
+                              description: RateLimitDescriptor defines a list of key-value
+                                pair generators.
+                              properties:
+                                entries:
+                                  description: Entries is the list of key-value pair
+                                    generators.
+                                  items:
+                                    description: |-
+                                      RateLimitDescriptorEntry is a key-value pair generator. Exactly
+                                      one field on this struct must be non-nil.
+                                    properties:
+                                      genericKey:
+                                        description: GenericKey defines a descriptor
+                                          entry with a static key and value.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              Key defines the key of the descriptor entry. If not set, the
+                                              key is set to "generic_key".
+                                            type: string
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - value
+                                        type: object
+                                      remoteAddress:
+                                        description: |-
+                                          RemoteAddress defines a descriptor entry with a key of "remote_address"
+                                          and a value equal to the client's IP address (from x-forwarded-for).
+                                        type: object
+                                      requestHeader:
+                                        description: |-
+                                          RequestHeader defines a descriptor entry that's populated only if
+                                          a given header is present on the request. The descriptor key is static,
+                                          and the descriptor value is equal to the value of the header.
+                                        properties:
+                                          descriptorKey:
+                                            description: DescriptorKey defines the
+                                              key to use on the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                          headerName:
+                                            description: HeaderName defines the name
+                                              of the header to look for on the request.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - descriptorKey
+                                        - headerName
+                                        type: object
+                                      requestHeaderValueMatch:
+                                        description: |-
+                                          RequestHeaderValueMatch defines a descriptor entry that's populated
+                                          if the request's headers match a set of 1+ match criteria. The
+                                          descriptor key is "header_match", and the descriptor value is static.
+                                        properties:
+                                          expectMatch:
+                                            default: true
+                                            description: |-
+                                              ExpectMatch defines whether the request must positively match the match
+                                              criteria in order to generate a descriptor entry (i.e. true), or not
+                                              match the match criteria in order to generate a descriptor entry (i.e. false).
+                                              The default is true.
+                                            type: boolean
+                                          headers:
+                                            description: |-
+                                              Headers is a list of 1+ match criteria to apply against the request
+                                              to determine whether to populate the descriptor entry or not.
+                                            items:
+                                              description: |-
+                                                HeaderMatchCondition specifies how to conditionally match against HTTP
+                                                headers. The Name field is required, only one of Present, NotPresent,
+                                                Contains, NotContains, Exact, NotExact and Regex can be set.
+                                                For negative matching rules only (e.g. NotContains or NotExact) you can set
+                                                TreatMissingAsEmpty.
+                                                IgnoreCase has no effect for Regex.
+                                              properties:
+                                                contains:
+                                                  description: |-
+                                                    Contains specifies a substring that must be present in
+                                                    the header value.
+                                                  type: string
+                                                exact:
+                                                  description: Exact specifies a string
+                                                    that the header value must be
+                                                    equal to.
+                                                  type: string
+                                                ignoreCase:
+                                                  description: |-
+                                                    IgnoreCase specifies that string matching should be case insensitive.
+                                                    Note that this has no effect on the Regex parameter.
+                                                  type: boolean
+                                                name:
+                                                  description: |-
+                                                    Name is the name of the header to match against. Name is required.
+                                                    Header names are case insensitive.
+                                                  type: string
+                                                notcontains:
+                                                  description: |-
+                                                    NotContains specifies a substring that must not be present
+                                                    in the header value.
+                                                  type: string
+                                                notexact:
+                                                  description: |-
+                                                    NoExact specifies a string that the header value must not be
+                                                    equal to. The condition is true if the header has any other value.
+                                                  type: string
+                                                notpresent:
+                                                  description: |-
+                                                    NotPresent specifies that condition is true when the named header
+                                                    is not present. Note that setting NotPresent to false does not
+                                                    make the condition true if the named header is present.
+                                                  type: boolean
+                                                present:
+                                                  description: |-
+                                                    Present specifies that condition is true when the named header
+                                                    is present, regardless of its value. Note that setting Present
+                                                    to false does not make the condition true if the named header
+                                                    is absent.
+                                                  type: boolean
+                                                regex:
+                                                  description: |-
+                                                    Regex specifies a regular expression pattern that must match the header
+                                                    value.
+                                                  type: string
+                                                treatMissingAsEmpty:
+                                                  description: |-
+                                                    TreatMissingAsEmpty specifies if the header match rule specified header
+                                                    does not exist, this header value will be treated as empty. Defaults to false.
+                                                    Unlike the underlying Envoy implementation this is **only** supported for
+                                                    negative matches (e.g. NotContains, NotExact).
+                                                  type: boolean
+                                              required:
+                                              - name
+                                              type: object
+                                            minItems: 1
+                                            type: array
+                                          value:
+                                            description: Value defines the value of
+                                              the descriptor entry.
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - value
+                                        type: object
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              required:
+                              - entries
+                              type: object
+                            minItems: 1
+                            type: array
+                          disabled:
+                            description: |-
+                              Disabled configures the HTTPProxy to not use
+                              the default global rate limit policy defined by the Contour configuration.
+                            type: boolean
+                        type: object
+                      local:
+                        description: |-
+                          Local defines local rate limiting parameters, i.e. parameters
+                          for rate limiting that occurs within each Envoy pod as requests
+                          are handled.
+                        properties:
+                          burst:
+                            description: |-
+                              Burst defines the number of requests above the requests per
+                              unit that should be allowed within a short period of time.
+                            format: int32
+                            type: integer
+                          requests:
+                            description: |-
+                              Requests defines how many requests per unit of time should
+                              be allowed before rate limiting occurs.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          responseHeadersToAdd:
+                            description: |-
+                              ResponseHeadersToAdd is an optional list of response headers to
+                              set when a request is rate-limited.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          responseStatusCode:
+                            description: |-
+                              ResponseStatusCode is the HTTP status code to use for responses
+                              to rate-limited requests. Codes must be in the 400-599 range
+                              (inclusive). If not specified, the Envoy default of 429 (Too
+                              Many Requests) is used.
+                            format: int32
+                            maximum: 599
+                            minimum: 400
+                            type: integer
+                          unit:
+                            description: |-
+                              Unit defines the period of time within which requests
+                              over the limit will be rate limited. Valid values are
+                              "second", "minute" and "hour".
+                            enum:
+                            - second
+                            - minute
+                            - hour
+                            type: string
+                        required:
+                        - requests
+                        - unit
+                        type: object
+                    type: object
+                  tls:
+                    description: |-
+                      If present the fields describes TLS properties of the virtual
+                      host. The SNI names that will be matched on are described in fqdn,
+                      the tls.secretName secret must contain a certificate that itself
+                      contains a name that matches the FQDN.
+                    properties:
+                      clientValidation:
+                        description: |-
+                          ClientValidation defines how to verify the client certificate
+                          when an external client establishes a TLS connection to Envoy.
+                          This setting:
+                          1. Enables TLS client certificate validation.
+                          2. Specifies how the client certificate will be validated (i.e.
+                             validation required or skipped).
+                          Note: Setting client certificate validation to be skipped should
+                          be only used in conjunction with an external authorization server that
+                          performs client validation as Contour will ensure client certificates
+                          are passed along.
+                        properties:
+                          caSecret:
+                            description: |-
+                              Name of a Kubernetes secret that contains a CA certificate bundle.
+                              The secret must contain key named ca.crt.
+                              The client certificate must validate against the certificates in the bundle.
+                              If specified and SkipClientCertValidation is true, client certificates will
+                              be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                            minLength: 1
+                            type: string
+                          crlOnlyVerifyLeafCert:
+                            description: |-
+                              If this option is set to true, only the certificate at the end of the
+                              certificate chain will be subject to validation by CRL.
+                            type: boolean
+                          crlSecret:
+                            description: |-
+                              Name of a Kubernetes opaque secret that contains a concatenated list of PEM encoded CRLs.
+                              The secret must contain key named crl.pem.
+                              This field will be used to verify that a client certificate has not been revoked.
+                              CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert is true.
+                              Large CRL lists are not supported since individual secrets are limited to 1MiB in size.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                            minLength: 1
+                            type: string
+                          forwardClientCertificate:
+                            description: |-
+                              ForwardClientCertificate adds the selected data from the passed client TLS certificate
+                              to the x-forwarded-client-cert header.
+                            properties:
+                              cert:
+                                description: Client cert in URL encoded PEM format.
+                                type: boolean
+                              chain:
+                                description: Client cert chain (including the leaf
+                                  cert) in URL encoded PEM format.
+                                type: boolean
+                              dns:
+                                description: DNS type Subject Alternative Names of
+                                  the client cert.
+                                type: boolean
+                              subject:
+                                description: Subject of the client cert.
+                                type: boolean
+                              uri:
+                                description: URI type Subject Alternative Name of
+                                  the client cert.
+                                type: boolean
+                            type: object
+                          optionalClientCertificate:
+                            description: |-
+                              OptionalClientCertificate when set to true will request a client certificate
+                              but allow the connection to continue if the client does not provide one.
+                              If a client certificate is sent, it will be verified according to the
+                              other properties, which includes disabling validation if
+                              SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
+                          skipClientCertValidation:
+                            description: |-
+                              SkipClientCertValidation disables downstream client certificate
+                              validation. Defaults to false. This field is intended to be used in
+                              conjunction with external authorization in order to enable the external
+                              authorization server to validate client certificates. When this field
+                              is set to true, client certificates are requested but not verified by
+                              Envoy. If CACertificate is specified, client certificates are required on
+                              requests, but not verified. If external authorization is in use, they are
+                              presented to the external authorization server.
+                            type: boolean
+                        type: object
+                      enableFallbackCertificate:
+                        description: |-
+                          EnableFallbackCertificate defines if the vhost should allow a default certificate to
+                          be applied which handles all requests which don't match the SNI defined in this vhost.
+                        type: boolean
+                      maximumProtocolVersion:
+                        description: |-
+                          MaximumProtocolVersion is the maximum TLS version this vhost should
+                          negotiate. Valid options are `1.2` and `1.3` (default). Any other value
+                          defaults to TLS 1.3.
+                        type: string
+                      minimumProtocolVersion:
+                        description: |-
+                          MinimumProtocolVersion is the minimum TLS version this vhost should
+                          negotiate. Valid options are `1.2` (default) and `1.3`. Any other value
+                          defaults to TLS 1.2.
+                        type: string
+                      passthrough:
+                        description: |-
+                          Passthrough defines whether the encrypted TLS handshake will be
+                          passed through to the backing cluster. Either Passthrough or
+                          SecretName must be specified, but not both.
+                        type: boolean
+                      secretName:
+                        description: |-
+                          SecretName is the name of a TLS secret.
+                          Either SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN.
+                          The name can be optionally prefixed with namespace "namespace/name".
+                          When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
+                        type: string
+                    type: object
+                required:
+                - fqdn
+                type: object
+            type: object
+          status:
+            default:
+              currentStatus: NotReconciled
+              description: Waiting for controller
+            description: Status is a container for computed information about the
+              HTTPProxy.
+            properties:
+              conditions:
+                description: |-
+                  Conditions contains information about the current status of the HTTPProxy,
+                  in an upstream-friendly container.
+                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
+                  and vice versa.
+                  Contour will leave untouched any other Conditions set in this block,
+                  in case some other controller wants to add a Condition.
+                  If you are another controller owner and wish to add a condition, you *should*
+                  namespace your condition with a label, like `controller.domain.com/ConditionName`.
+                items:
+                  description: |-
+                    DetailedCondition is an extension of the normal Kubernetes conditions, with two extra
+                    fields to hold sub-conditions, which provide more detailed reasons for the state (True or False)
+                    of the condition.
+                    `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
+                    `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
+                    Remember that Conditions have a type, a status, and a reason.
+                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
+                    In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
+                    `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
+                    slice in this case.
+                    `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
+                    The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`.
+                    For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
+                    When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
+                    In either case, there may be entries in the `warnings` slice.
+                    Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason
+                    (if there is one and only one entry in total across both the `errors` and `warnings` slices), or
+                    `MultipleReasons` if there is more than one entry.
+                  properties:
+                    errors:
+                      description: |-
+                        Errors contains a slice of relevant error subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: |-
+                        Warnings contains a slice of relevant warning subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant.
+                        An empty slice here indicates no warnings.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentStatus:
+                type: string
+              description:
+                type: string
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load
+                  balancer.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
+                          type: string
+                        ports:
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
+                          items:
+                            description: PortStatus represents the error condition
+                              of a service port
+                            properties:
+                              error:
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
+                                type: string
+                            required:
+                            - error
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tlscertificatedelegations.projectcontour.io
+spec:
+  preserveUnknownFields: false
+  group: projectcontour.io
+  names:
+    kind: TLSCertificateDelegation
+    listKind: TLSCertificateDelegationList
+    plural: tlscertificatedelegations
+    shortNames:
+    - tlscerts
+    singular: tlscertificatedelegation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
+          See design/tls-certificate-delegation.md for details.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSCertificateDelegationSpec defines the spec of the CRD
+            properties:
+              delegations:
+                items:
+                  description: |-
+                    CertificateDelegation maps the authority to reference a secret
+                    in the current namespace to a set of namespaces.
+                  properties:
+                    secretName:
+                      description: required, the name of a secret in the current namespace.
+                      type: string
+                    targetNamespaces:
+                      description: |-
+                        required, the namespaces the authority to reference the
+                        secret will be delegated to.
+                        If TargetNamespaces is nil or empty, the CertificateDelegation'
+                        is ignored. If the TargetNamespace list contains the character, "*"
+                        the secret will be delegated to all namespaces.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - secretName
+                  - targetNamespaces
+                  type: object
+                type: array
+            required:
+            - delegations
+            type: object
+          status:
+            description: |-
+              TLSCertificateDelegationStatus allows for the status of the delegation
+              to be presented to the user.
+            properties:
+              conditions:
+                description: |-
+                  Conditions contains information about the current status of the HTTPProxy,
+                  in an upstream-friendly container.
+                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
+                  and vice versa.
+                  Contour will leave untouched any other Conditions set in this block,
+                  in case some other controller wants to add a Condition.
+                  If you are another controller owner and wish to add a condition, you *should*
+                  namespace your condition with a label, like `controller.domain.com\ConditionName`.
+                items:
+                  description: |-
+                    DetailedCondition is an extension of the normal Kubernetes conditions, with two extra
+                    fields to hold sub-conditions, which provide more detailed reasons for the state (True or False)
+                    of the condition.
+                    `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
+                    `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
+                    Remember that Conditions have a type, a status, and a reason.
+                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
+                    In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
+                    `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
+                    slice in this case.
+                    `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
+                    The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
+                    slice if `status` is `false`.
+                    For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
+                    When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
+                    When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
+                    In either case, there may be entries in the `warnings` slice.
+                    Regardless of the polarity, the `reason` and `message` fields must be updated with either the detail of the reason
+                    (if there is one and only one entry in total across both the `errors` and `warnings` slices), or
+                    `MultipleReasons` if there is more than one entry.
+                  properties:
+                    errors:
+                      description: |-
+                        Errors contains a slice of relevant error subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant.
+                        An empty slice here indicates no errors.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    warnings:
+                      description: |-
+                        Warnings contains a slice of relevant warning subconditions for this object.
+                        Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant.
+                        An empty slice here indicates no warnings.
+                      items:
+                        description: |-
+                          SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition.
+                          It contains a subset of the Condition fields.
+                          It is intended for warnings and errors, so `type` names should use abnormal-true polarity,
+                          that is, they should be of the form "ErrorPresent: true".
+                          The expected lifecycle for these errors is that they should only be present when the error or warning is,
+                          and should be removed when they are not relevant.
+                        properties:
+                          message:
+                            description: |-
+                              Message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          reason:
+                            description: |-
+                              Reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/contour-crds/templates/gateway-api-crds.yaml
+++ b/charts/contour-crds/templates/gateway-api-crds.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.enableGatewayCRDs }}
+{{- $.Files.Get "src/raw-gateway-api-crds.yaml" -}}
+{{- end }}

--- a/charts/contour-crds/update-crds.sh
+++ b/charts/contour-crds/update-crds.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+here="$(cd -- "$(dirname "$0")" > /dev/null 2>&1 || exit; pwd -P)"
+# replace this with `yq .appVersion "${here}/Chart.yaml"` if yq is reliably available
+version="$(grep 'appVersion:' "${here}/Chart.yaml" | cut -d':' -f2 | tr -d ' ' | cut -d'"' -f2 | cut -d"'" -f2)"
+
+curl -L -o "${here}/src/raw-gateway-crds.yaml" "https://raw.githubusercontent.com/projectcontour/contour/v${version}/examples/gateway/00-crds.yaml"
+curl -L -o "${here}/templates/contour-crds.yaml" "https://raw.githubusercontent.com/projectcontour/contour/v${version}/examples/contour/01-crds.yaml"

--- a/charts/contour-crds/values.yaml
+++ b/charts/contour-crds/values.yaml
@@ -1,0 +1,2 @@
+enableGatewayCRDs: true
+

--- a/charts/contour-gateway-provisioner/Chart.yaml
+++ b/charts/contour-gateway-provisioner/Chart.yaml
@@ -1,0 +1,22 @@
+annotations:
+  category: Infrastructure
+  licenses: Apache-2.0
+apiVersion: v2
+appVersion: 1.32.1
+description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
+home: https://projectcontour.io/
+keywords:
+- ingress
+- envoy
+- contour
+maintainers:
+- name: Contour Team
+name: contour-gateway-provisioner
+sources:
+- https://github.com/projectcontour/helm-charts/tree/main/charts/contour-gateway-provisioner
+version: 0.1.0
+dependencies:
+- name: contour-crds
+  repository: https://projectcontour.github.io/helm-charts
+  version: 0.1.0
+  condition: contour-crds.enabled

--- a/charts/contour-gateway-provisioner/templates/_helpers.tpl
+++ b/charts/contour-gateway-provisioner/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "contour-gateway-provisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "contour-gateway-provisioner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "contour-gateway-provisioner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "contour-gateway-provisioner.labels" -}}
+helm.sh/chart: {{ include "contour-gateway-provisioner.chart" . }}
+{{ include "contour-gateway-provisioner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "contour-gateway-provisioner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "contour-gateway-provisioner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "contour-gateway-provisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "contour-gateway-provisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/contour-gateway-provisioner/templates/deployment.yaml
+++ b/charts/contour-gateway-provisioner/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "contour-gateway-provisioner.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "contour-gateway-provisioner.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "contour-gateway-provisioner.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: CONTOUR_PROVISIONER_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          command: ["contour"]
+          args:
+          - gateway-provisioner
+          - --metrics-addr=127.0.0.1:8080
+          - --enable-leader-election
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/contour-gateway-provisioner/templates/rbac.yaml
+++ b/charts/contour-gateway-provisioner/templates/rbac.yaml
@@ -1,0 +1,220 @@
+{{- if .Values.rbac.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies/status
+  - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - tcproutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations/status
+  - extensionservices/status
+  - httpproxies/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments
+  - extensionservices
+  - httpproxies
+  - tlscertificatedelegations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "contour-gateway-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "contour-gateway-provisioner.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "contour-gateway-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/contour-gateway-provisioner/templates/serviceaccount.yaml
+++ b/charts/contour-gateway-provisioner/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "contour-gateway-provisioner.serviceAccountName" . }}
+  labels:
+    {{- include "contour-gateway-provisioner.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/contour-gateway-provisioner/values.yaml
+++ b/charts/contour-gateway-provisioner/values.yaml
@@ -1,0 +1,88 @@
+# Default values for contour-gateway-provisioner.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/projectcontour/contour
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  # Specifies whether the roles and bindings should be created
+  create: true
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {} # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 70Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 70Mi
+
+  # Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+contour-crds:
+  enabled: true
+  enableGatewayCRDs: true


### PR DESCRIPTION
As suggested in #3 a PR that introduces a chart for the gateway provisioner. I needed to build this anyway, because we standardized on deployments using helm. As a preparation I've also added a chart for the CRDs, which could be pulled by the main contour chart as well.

What I considered, but didn't do in this PR:

* change the contour chart to pull contour-crds
* pull the gateway-api CRDs via `oci://docker.io/envoyproxy/gateway-crds-helm`