### PR TITLE
Remove Bitnami documentation from NOTES

### DIFF
--- a/charts/contour/templates/NOTES.txt
+++ b/charts/contour/templates/NOTES.txt
@@ -2,10 +2,6 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
-⚠ WARNING: Since August 28th, 2025, only a limited subset of images/charts are available for free.
-    Subscribe to Bitnami Secure Images to receive continued support and security updates.
-    More info at https://bitnami.com and https://github.com/bitnami/containers/issues/83267
-
 ** Please be patient while the chart is being deployed **
 
 {{- if eq .Values.envoy.service.type "LoadBalancer" }}


### PR DESCRIPTION
Removes the Bitnami deprecation notice from the post-install/upgrade `NOTES.txt`.