### PR TITLE
Add Artifact Hub metadata file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,13 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: b9186cff-cced-42cd-ba80-cc657521fce0
+

--- a/index.yaml
+++ b/index.yaml
@@ -5,6 +5,29 @@ entries:
       category: Infrastructure
       licenses: Apache-2.0
     apiVersion: v2
+    appVersion: 1.33.3
+    created: "2026-03-30T10:05:48.174911032Z"
+    description: Contour is an open source Kubernetes ingress controller that works
+      by deploying the Envoy proxy as a reverse proxy and load balancer.
+    digest: b19df99879d637900df19d17aa6296fa33e3dc614f17709177143c2aad871242
+    home: https://projectcontour.io/
+    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/contour/icon/color/contour-icon-color.svg
+    keywords:
+    - ingress
+    - envoy
+    - contour
+    maintainers:
+    - name: Contour Team
+    name: contour
+    sources:
+    - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
+    urls:
+    - https://github.com/deepy/projectcontour-charts/releases/download/contour-0.4.0/contour-0.4.0.tgz
+    version: 0.4.0
+  - annotations:
+      category: Infrastructure
+      licenses: Apache-2.0
+    apiVersion: v2
     appVersion: 1.32.0
     created: "2025-09-26T08:11:20.331130729Z"
     description: Contour is an open source Kubernetes ingress controller that works
@@ -23,4 +46,4 @@ entries:
     urls:
     - https://github.com/projectcontour/helm-charts/releases/download/contour-0.1.0/contour-0.1.0.tgz
     version: 0.1.0
-generated: "2025-09-26T08:11:20.331140708Z"
+generated: "2026-03-30T10:05:48.174921071Z"

--- a/index.yaml
+++ b/index.yaml
@@ -5,6 +5,29 @@ entries:
       category: Infrastructure
       licenses: Apache-2.0
     apiVersion: v2
+    appVersion: 1.33.5
+    created: "2026-08-08T13:17:13.221788103Z"
+    description: Contour is an open source Kubernetes ingress controller that works
+      by deploying the Envoy proxy as a reverse proxy and load balancer.
+    digest: 6f79868cb64fb31195ed5520dd681fdb9de30fcce03153ea3d29e3b0fde265b0
+    home: https://projectcontour.io/
+    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/contour/icon/color/contour-icon-color.svg
+    keywords:
+    - ingress
+    - envoy
+    - contour
+    maintainers:
+    - name: Contour Team
+    name: contour
+    sources:
+    - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
+    urls:
+    - https://github.com/deepy/projectcontour-charts/releases/download/contour-0.6.0/contour-0.6.0.tgz
+    version: 0.6.0
+  - annotations:
+      category: Infrastructure
+      licenses: Apache-2.0
+    apiVersion: v2
     appVersion: 1.33.3
     created: "2026-03-30T10:05:48.174911032Z"
     description: Contour is an open source Kubernetes ingress controller that works
@@ -46,4 +69,4 @@ entries:
     urls:
     - https://github.com/projectcontour/helm-charts/releases/download/contour-0.1.0/contour-0.1.0.tgz
     version: 0.1.0
-generated: "2026-03-30T10:05:48.174921071Z"
+generated: "2026-08-08T13:17:13.221801088Z"

--- a/index.yaml
+++ b/index.yaml
@@ -6,6 +6,34 @@ entries:
       licenses: Apache-2.0
     apiVersion: v2
     appVersion: 1.33.5
+    created: "2026-08-08T13:28:13.03455413Z"
+    dependencies:
+    - condition: contour.manageCRDs
+      name: contour-crds
+      repository: file://../contour-crds
+      version: 0.7.0
+    description: Contour is an open source Kubernetes ingress controller that works
+      by deploying the Envoy proxy as a reverse proxy and load balancer.
+    digest: 964f12f1013df6a31c4f5b153b344989bef91286cdad35288030347305902081
+    home: https://projectcontour.io/
+    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/contour/icon/color/contour-icon-color.svg
+    keywords:
+    - ingress
+    - envoy
+    - contour
+    maintainers:
+    - name: Contour Team
+    name: contour
+    sources:
+    - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
+    urls:
+    - https://github.com/deepy/projectcontour-charts/releases/download/contour-0.7.0/contour-0.7.0.tgz
+    version: 0.7.0
+  - annotations:
+      category: Infrastructure
+      licenses: Apache-2.0
+    apiVersion: v2
+    appVersion: 1.33.5
     created: "2026-08-08T13:17:13.221788103Z"
     description: Contour is an open source Kubernetes ingress controller that works
       by deploying the Envoy proxy as a reverse proxy and load balancer.
@@ -69,4 +97,28 @@ entries:
     urls:
     - https://github.com/projectcontour/helm-charts/releases/download/contour-0.1.0/contour-0.1.0.tgz
     version: 0.1.0
-generated: "2026-08-08T13:17:13.221801088Z"
+  contour-crds:
+  - annotations:
+      category: Infrastructure
+      licenses: Apache-2.0
+    apiVersion: v2
+    appVersion: 1.33.3
+    created: "2026-08-08T13:28:13.222382224Z"
+    description: Contour is an open source Kubernetes ingress controller that works
+      by deploying the Envoy proxy as a reverse proxy and load balancer.
+    digest: 42fd6015f68475c9299d2fda2e94ed73648f0ec4d22f69290496bbde3b172016
+    home: https://projectcontour.io/
+    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/contour/icon/color/contour-icon-color.svg
+    keywords:
+    - ingress
+    - envoy
+    - contour
+    maintainers:
+    - name: Contour Team
+    name: contour-crds
+    sources:
+    - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
+    urls:
+    - https://github.com/deepy/projectcontour-charts/releases/download/contour-crds-0.7.0/contour-crds-0.7.0.tgz
+    version: 0.7.0
+generated: "2026-08-08T13:28:13.222393909Z"


### PR DESCRIPTION
I've created an organization on Artifact Hub and added the repository to it: https://artifacthub.io/packages/helm/contour/contour

This file allows Artifact Hub to verify us as the owner of the repository