### PR TITLE
Fix/envoy service account name flag

### DIFF
--- a/charts/contour/Chart.yaml
+++ b/charts/contour/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
-version: 0.6.0
+version: 0.6.1

--- a/charts/contour/Chart.yaml
+++ b/charts/contour/Chart.yaml
@@ -15,3 +15,4 @@ maintainers:
 name: contour
 sources:
   - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
+version: 0.6.0

--- a/charts/contour/Chart.yaml
+++ b/charts/contour/Chart.yaml
@@ -15,4 +15,3 @@ maintainers:
 name: contour
 sources:
   - https://github.com/projectcontour/helm-charts/tree/main/charts/contour
-version: 0.6.1

--- a/charts/contour/templates/_helpers.tpl
+++ b/charts/contour/templates/_helpers.tpl
@@ -9,7 +9,7 @@ SPDX-License-Identifier: APACHE-2.0
 Create the name of the envoy service account to use
 */}}
 {{- define "envoy.envoyServiceAccountName" -}}
-{{- if .Values.contour.serviceAccount.create -}}
+{{- if .Values.envoy.serviceAccount.create -}}
     {{ default (printf "%s-envoy" (include "common.names.fullname" .)) .Values.envoy.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.envoy.serviceAccount.name }}

--- a/test/e2e/contour_chart_test.go
+++ b/test/e2e/contour_chart_test.go
@@ -55,6 +55,47 @@ var _ = Describe("Contour", func() {
 		Expect(res.StatusCode).To(Equal(200))
 	}
 
+	// Template-only regression tests. These render the chart client-side and
+	// do not require a Kind cluster (they are intentionally declared outside
+	// f.NamespacedTest, which is what provisions a cluster).
+	Describe("service account name helpers", func() {
+		// Regression for the envoy.envoyServiceAccountName helper, which used to
+		// gate the rendered name on contour.serviceAccount.create instead of
+		// envoy.serviceAccount.create. With divergent flags that produced an
+		// envoy ServiceAccount object rendered with the name "default".
+		It("derives the envoy ServiceAccount name from envoy.serviceAccount.create", func() {
+			rendered := HelmTemplate(releaseName, chartPath,
+				"--show-only", "templates/envoy/serviceaccount.yaml",
+				"--set", "contour.serviceAccount.create=false",
+				"--set", "envoy.serviceAccount.create=true",
+			)
+
+			Expect(rendered).To(MatchRegexp(`(?m)^\s*name:\s+\S+-envoy\s*$`),
+				"envoy ServiceAccount should use its dedicated <fullname>-envoy name")
+			Expect(rendered).NotTo(MatchRegexp(`(?m)^\s*name:\s+default\s*$`),
+				"envoy ServiceAccount must not be named \"default\" when envoy.serviceAccount.create=true")
+		})
+
+		// The envoy ServiceAccount object is created based on
+		// envoy.serviceAccount.create, so when it is disabled the envoy workload
+		// must fall back to the "default" account rather than referencing a
+		// dedicated <fullname>-envoy account that is never created. Before the
+		// fix, the helper followed contour.serviceAccount.create and produced
+		// such a dangling reference.
+		It("falls back to the default SA for envoy when envoy.serviceAccount.create=false", func() {
+			rendered := HelmTemplate(releaseName, chartPath,
+				"--show-only", "templates/envoy/daemonset.yaml",
+				"--set", "contour.serviceAccount.create=true",
+				"--set", "envoy.serviceAccount.create=false",
+			)
+
+			Expect(rendered).To(MatchRegexp(`(?m)^\s*serviceAccountName:\s+default\s*$`),
+				"envoy workload should use the default SA when envoy.serviceAccount.create=false")
+			Expect(rendered).NotTo(MatchRegexp(`(?m)^\s*serviceAccountName:\s+\S+-envoy\s*$`),
+				"envoy workload must not reference a dedicated SA that is not created")
+		})
+	})
+
 	f.NamespacedTest("test-helm-installation", func(namespace string) {
 		It("should deploy contour using helm", func() {
 			helmRelease := HelmInstall(releaseName, chartPath, namespace, mandatoryInstallArgs...)

--- a/test/e2e/helm.go
+++ b/test/e2e/helm.go
@@ -33,6 +33,7 @@ const (
 	helmUpgradeTimeout   = 5 * time.Minute
 	helmUninstallTimeout = 1 * time.Minute
 	helmRepoTimeout      = 3 * time.Minute
+	helmTemplateTimeout  = 1 * time.Minute
 )
 
 func HelmInstall(releaseName, chartPath, namespace string, additionalArgs ...string) *Helm {
@@ -70,6 +71,15 @@ func (h *Helm) Uninstall() {
 // run executes a helm command and fails the test if it exits non-zero.
 func (h *Helm) runWithTimeout(cmdArgs []string, timeout time.Duration) {
 	runCommand(cmdArgs[0], timeout, false, nil, cmdArgs[1:]...)
+}
+
+// HelmTemplate renders the chart locally (client-side, no cluster required)
+// with the given additional args and returns the rendered manifests.
+func HelmTemplate(releaseName, chartPath string, additionalArgs ...string) string {
+	var stdout bytes.Buffer
+	cmdArgs := append([]string{"template", releaseName, chartPath}, additionalArgs...)
+	runCommand("helm", helmTemplateTimeout, false, &stdout, cmdArgs...)
+	return stdout.String()
 }
 
 // HelmRepoAdd adds a Helm repository and updates its index.


### PR DESCRIPTION
## What this does

Fixes the `envoy.envoyServiceAccountName` template helper, which gated the generated name on `.Values.contour.serviceAccount.create` instead of `.Values.envoy.serviceAccount.create`.
  
## The bug
  
`charts/contour/templates/_helpers.tpl`:
  
```gotemplate
{{- define "envoy.envoyServiceAccountName" -}}
{{- if .Values.contour.serviceAccount.create -}}   {{/* wrong flag */}}
    {{ default (printf "%s-envoy" (include "common.names.fullname" .))
.Values.envoy.serviceAccount.name }}
{{- else -}}
    {{ default "default" .Values.envoy.serviceAccount.name }}
{{- end -}}
{{- end -}}
```
  
The envoy ServiceAccount object (`templates/envoy/serviceaccount.yaml`) is created based on `.Values.envoy.serviceAccount.create`, and the parallel `contour.contourServiceAccountName` helper consistently keys off the contour flag. Only the envoy name helper looks at the contour flag, so the object guard and the name diverge whenever the two `serviceAccount.create` values differ.

Impact

With default values (`contour.serviceAccount.create=true`, `envoy.serviceAccount.create=true`) there is no visible symptom, so this stays latent. It breaks when the two flags diverge:

- `contour.serviceAccount.create=false`, `envoy.serviceAccount.create=true`:
the envoy ServiceAccount object is created but rendered with the name default, colliding with the namespace default SA; the envoy workload does not get its dedicated account.
- `contour.serviceAccount.create=true`, `envoy.serviceAccount.create=false`:
no envoy ServiceAccount object is created, yet the envoy DaemonSet/Deployment still reference <fullname>-envoy, a name that does not exist.

The fix

Gate the helper on `.Values.envoy.serviceAccount.create` so the name matches its object template and mirrors the contour-side helper. Chart version bumped 0.6.0 -> 0.6.1.

Tests

Adds two render-level regression tests in test/e2e (client-side helm template, no cluster required) that pin the helper to the envoy flag:

- divergent flags -> envoy ServiceAccount uses its dedicated <fullname>-envoy name, never default;
- `envoy.serviceAccount.create=false` -> the envoy workload falls back to the default SA instead of referencing an uncreated <fullname>-envoy.

Both fail against the previous helper and pass with the fix.

Verification

- helm lint --strict charts/contour/ - pass
- golangci-lint run --build-tags=e2e - 0 issues
- make e2e (Kind) - 2 Passed | 0 Failed (deploy + upgrade-from-published)
- New regression specs - pass with the fix, fail when reverted